### PR TITLE
smaller bugfixes unrelated to any issues

### DIFF
--- a/scripts/aiplayer.gd
+++ b/scripts/aiplayer.gd
@@ -153,7 +153,7 @@ func exploded(by_who):
 	stunned = true
 	lives -= 1
 	hurt_sfx_player.play()
-	if str(by_who) == get_player_name():
+	if str(by_who) == name:
 		$"../../GameUI".decrease_score(by_who) # Take away a point for blowing yourself up
 	else:
 		$"../../GameUI".increase_score(by_who) # Award a point to the person who blew you up

--- a/scripts/lobby.gd
+++ b/scripts/lobby.gd
@@ -63,7 +63,7 @@ func _on_game_ended():
 	$Connect.show()
 	$Players.hide()
 	$Back.show()
-	$Options.hide()
+	$Options.show()
 	$CSS.hide()
 	$Connect/Host.disabled = false
 	$Connect/Join.disabled = false

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -5,7 +5,9 @@ func _ready() -> void:
 	$ButtonBox/SinglePlayer.grab_focus()
 
 func _on_single_player_pressed() -> void:
-	gamestate.begin_singleplayer_game()
+	#if a game is already running do not allow a new game to start
+	if !has_node("/root/World"):
+		gamestate.begin_singleplayer_game()
 	# get_tree().change_scene_to_file("res://scenes/battlegrounds.tscn")
 
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -121,7 +121,7 @@ func exploded(by_who):
 	stunned = true
 	lives -= 1
 	hurt_sfx_player.play()
-	if str(by_who) == get_player_name():
+	if str(by_who) == name: 
 		$"../../GameUI".decrease_score(by_who) # Take away a point for blowing yourself up
 	else:
 		$"../../GameUI".increase_score(by_who) # Award a point to the person who blew you up


### PR DESCRIPTION
Fixes the following bugs:

- Score is now correctly reduced if player dies to their own bombs. (old behavior: player got a point even if killed by their own bomb)
- When exiting a multiplayer game and the player is sent back to the lobby the "option" menu is now visible. (old behavior: while the host and join button where visible, tho "option" menu to set AI amount was not)
- Game now does not crash when using the space button in a single player game. (old behavior: As the menu root still exists in the current implementation of single player pressing space called the begin_singleplayer_game() function which crashes the game)