### PR TITLE
experimentel bombpool and bomb rework

### DIFF
--- a/scenes/battlegrounds.tscn
+++ b/scenes/battlegrounds.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=16 format=4 uid="uid://bs7slglsckv0i"]
+[gd_scene load_steps=20 format=4 uid="uid://bs7slglsckv0i"]
 
 [ext_resource type="Script" path="res://scripts/world.gd" id="1_b42q6"]
 [ext_resource type="Script" path="res://scripts/game_ui.gd" id="3_dadsx"]
 [ext_resource type="Script" path="res://scripts/misobon_path.gd" id="3_uhlbr"]
 [ext_resource type="TileSet" uid="uid://c5k358s71dvg7" path="res://assets/deserttileset.tres" id="3_vcixd"]
+[ext_resource type="PackedScene" uid="uid://c4i5gyl4cut3t" path="res://scenes/bomb/bomb_pool.tscn" id="4_er4o6"]
 [ext_resource type="Script" path="res://scripts/player_spawner.gd" id="5_2eagj"]
 [ext_resource type="FontFile" uid="uid://knb8u535cfkw" path="res://montserrat.otf" id="5_g2doi"]
 [ext_resource type="Script" path="res://scripts/bomb_spawner.gd" id="6_xje61"]
@@ -71,6 +72,8 @@ visible = false
 [node name="MisobonPath" type="Path2D" parent="."]
 curve = SubResource("Curve2D_pquxm")
 script = ExtResource("3_uhlbr")
+
+[node name="BombPool" parent="." instance=ExtResource("4_er4o6")]
 
 [node name="GameUI" type="CanvasLayer" parent="."]
 visible = false
@@ -234,7 +237,7 @@ spawn_path = NodePath("../MisobonPath")
 script = ExtResource("7_7cqae")
 
 [node name="BombSpawner" type="MultiplayerSpawner" parent="."]
-spawn_path = NodePath("..")
+spawn_path = NodePath("../BombPool")
 script = ExtResource("6_xje61")
 bomb_audio_stream = ExtResource("7_cxllj")
 

--- a/scenes/bomb/bomb_pool.tscn
+++ b/scenes/bomb/bomb_pool.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://c4i5gyl4cut3t"]
+
+[ext_resource type="Script" path="res://scripts/bomb_pool.gd" id="1_hpd1g"]
+
+[node name="BombPool" type="Node2D"]
+script = ExtResource("1_hpd1g")

--- a/scenes/bomb/bomb_root.tscn
+++ b/scenes/bomb/bomb_root.tscn
@@ -1,24 +1,10 @@
-[gd_scene load_steps=4 format=3 uid="uid://crrkmxwyf4bqw"]
+[gd_scene load_steps=3 format=3 uid="uid://crrkmxwyf4bqw"]
 
 [ext_resource type="Script" path="res://scripts/bomb_root_fsm.gd" id="1_pel47"]
 [ext_resource type="PackedScene" uid="uid://enwoaqi0rnei" path="res://scenes/bomb/stationary_bomb.tscn" id="2_ijtvv"]
-
-[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_xhgnx"]
-properties/0/path = NodePath("StationaryBomb:synced_position")
-properties/0/spawn = true
-properties/0/replication_mode = 1
-properties/1/path = NodePath("StationaryBomb:init")
-properties/1/spawn = true
-properties/1/replication_mode = 1
-properties/2/path = NodePath("StationaryBomb:exit")
-properties/2/spawn = true
-properties/2/replication_mode = 1
 
 [node name="BombRoot" type="Node2D"]
 script = ExtResource("1_pel47")
 
 [node name="StationaryBomb" parent="." instance=ExtResource("2_ijtvv")]
 unique_name_in_owner = true
-
-[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="."]
-replication_config = SubResource("SceneReplicationConfig_xhgnx")

--- a/scenes/bomb/bomb_root.tscn
+++ b/scenes/bomb/bomb_root.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=4 format=3 uid="uid://crrkmxwyf4bqw"]
+
+[ext_resource type="Script" path="res://scripts/bomb_root_fsm.gd" id="1_pel47"]
+[ext_resource type="PackedScene" uid="uid://enwoaqi0rnei" path="res://scenes/bomb/stationary_bomb.tscn" id="2_ijtvv"]
+
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_xhgnx"]
+properties/0/path = NodePath("StationaryBomb:synced_position")
+properties/0/spawn = true
+properties/0/replication_mode = 1
+properties/1/path = NodePath("StationaryBomb:init")
+properties/1/spawn = true
+properties/1/replication_mode = 1
+properties/2/path = NodePath("StationaryBomb:exit")
+properties/2/spawn = true
+properties/2/replication_mode = 1
+
+[node name="BombRoot" type="Node2D"]
+script = ExtResource("1_pel47")
+
+[node name="StationaryBomb" parent="." instance=ExtResource("2_ijtvv")]
+unique_name_in_owner = true
+
+[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="."]
+replication_config = SubResource("SceneReplicationConfig_xhgnx")

--- a/scenes/bomb/stationary_bomb.tscn
+++ b/scenes/bomb/stationary_bomb.tscn
@@ -74,7 +74,23 @@ tracks/0/keys = {
 "values": [&"explosion_small"]
 }
 
+[sub_resource type="Animation" id="Animation_m6l0e"]
+resource_name = "explosion_small"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(-0.0333333),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"explosion_small"]
+}
+
 [sub_resource type="Animation" id="Animation_21j5c"]
+resource_name = "fuse_and_call_explode()"
 length = 4.0
 tracks/0/type = "value"
 tracks/0/imported = false
@@ -106,29 +122,14 @@ tracks/1/keys = {
 }]
 }
 
-[sub_resource type="Animation" id="Animation_m6l0e"]
-resource_name = "explosion_small"
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:animation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(-0.0333333),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [&"explosion_small"]
-}
-
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_h2w7m"]
 _data = {
 "RESET": SubResource("Animation_oq2m5"),
-"anim": SubResource("Animation_21j5c"),
-"explosion_small": SubResource("Animation_m6l0e")
+"explosion_small": SubResource("Animation_m6l0e"),
+"fuse_and_call_explode()": SubResource("Animation_21j5c")
 }
 
-[node name="Bomb" type="StaticBody2D"]
+[node name="StationaryBomb" type="StaticBody2D"]
 texture_filter = 1
 collision_layer = 8
 collision_mask = 6
@@ -177,7 +178,6 @@ animation = &"explosion_small"
 libraries = {
 "": SubResource("AnimationLibrary_h2w7m")
 }
-autoplay = "anim"
 
 [node name="BombSprite" type="Sprite2D" parent="."]
 texture = ExtResource("8_1u1d1")

--- a/scenes/misobon_aiplayer.tscn
+++ b/scenes/misobon_aiplayer.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://cm07fhl1g383h"]
+[gd_scene load_steps=17 format=3 uid="uid://bsndu4n0j4hva"]
 
 [ext_resource type="Script" path="res://scripts/misobon_aiplayer.gd" id="1_iupa5"]
 [ext_resource type="Texture2D" uid="uid://cpi4w3fgdon0o" path="res://assets/player/playershadow.png" id="2_lkx36"]

--- a/scenes/misobon_player.tscn
+++ b/scenes/misobon_player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://it7oy2orrn60"]
+[gd_scene load_steps=17 format=3 uid="uid://qnn4bkknt2vc"]
 
 [ext_resource type="Texture2D" uid="uid://cpi4w3fgdon0o" path="res://assets/player/playershadow.png" id="1_50gef"]
 [ext_resource type="Script" path="res://scripts/misobon_player.gd" id="1_ewgms"]

--- a/scripts/bomb.gd
+++ b/scripts/bomb.gd
@@ -22,30 +22,6 @@ const MAX_EXPLOSION_WIDTH = 8
 func _ready():
 	explosion_sfx_player.set_stream(explosion_audio)
 
-func _process(_delta):
-	if multiplayer.multiplayer_peer == null or is_multiplayer_authority():
-		synced_position = position
-	else:
-		position = synced_position
-	if init:
-		self.visible = true
-		$CollisionShape2D.set_deferred("disabled", 1)
-		$DetectArea.set_deferred("disabled", 0)
-		$AnimationPlayer.play("fuse_and_call_explode()")
-		print("init")
-		if is_multiplayer_authority(): init = false
-	elif exit:
-		self.visible = false
-		$AnimationPlayer.stop()
-		$DetectArea.set_deferred("disabled", 1)
-		$CollisionShape2D.set_deferred("disabled", 1)
-		print("exit")
-		if is_multiplayer_authority(): exit = false
-
-
-
-
-
 func pass_bomb_owner():
 	from_player = str(get_parent().bomb_owner.name).to_int()
 
@@ -54,13 +30,21 @@ func disable():
 	in_area = []
 	animation_finish = false
 	explosion_width = 2
+	self.visible = false
+	$AnimationPlayer.stop()
+	$DetectArea.set_deferred("disabled", 1)
+	$CollisionShape2D.set_deferred("disabled", 1)
+
 	if is_multiplayer_authority(): exit = true
 	print("disabled: ", get_parent())
 	
 func place(bombPos: Vector2):
 	#TODO this should play the place audio
 	position = bombPos
-	if is_multiplayer_authority(): init = true
+	self.visible = true
+	$CollisionShape2D.set_deferred("disabled", 1)
+	$DetectArea.set_deferred("disabled", 0)
+	$AnimationPlayer.play("fuse_and_call_explode()")
 	print("place: ", get_parent(), ", visibility: ", 1 if self.visible else 0, ", pos: ", position, ", process_mode: ", process_mode) 
 
 

--- a/scripts/bomb_pool.gd
+++ b/scripts/bomb_pool.gd
@@ -1,0 +1,36 @@
+extends Node2D
+
+@onready var bomb_spawner: MultiplayerSpawner = get_node("../BombSpawner")
+
+func _ready():
+	pass
+
+func request_bomb(requester: Node2D) -> Node2D: #This function is called by the player when the number of bombs he holds is increased
+	if !is_multiplayer_authority(): return null
+	var tree = get_tree()
+	var bomb = tree.get_nodes_in_group("unowned").pop_back()
+	if bomb != null: #if there was an unowned bomb we add it to the group of the player #if there was an unowned bomb we add it to the group of the player
+		bomb.remove_from_group("unowned")
+		bomb.add_to_group(requester.name)
+		return bomb
+	# hence bomb == null which means no bomb is currently unowned and we need to request a new one from the spawner
+	bomb = bomb_spawner.spawn([str(requester.name).to_int()])
+	bomb.add_to_group(requester.name)
+	return bomb
+
+func request_bomb_array(requester: Node2D, count: int) -> Array[Node2D]:
+	var arr: Array[Node2D] = []
+	for _i in range(count):
+		arr.push_back(request_bomb(requester))
+	return arr
+
+func return_bomb(returner: Node2D, bomb: Node2D):
+	if(!bomb.is_in_group(returner.name)):
+		printerr(returner.name, "tried to return a bomb that is not owned by them")
+
+	bomb.remove_from_group(returner.name)
+	bomb.add_to_group("unowned")
+
+func return_bomb_array(returner: Node2D, bomb_array: Array[Node2D]):
+	for bomb in bomb_array:
+		return_bomb(returner, bomb)

--- a/scripts/bomb_pool.gd
+++ b/scripts/bomb_pool.gd
@@ -6,15 +6,14 @@ func _ready():
 	pass
 
 func request_bomb(requester: Node2D) -> Node2D: #This function is called by the player when the number of bombs he holds is increased
-	if !is_multiplayer_authority(): return null
 	var tree = get_tree()
 	var bomb = tree.get_nodes_in_group("unowned").pop_back()
-	if bomb != null: #if there was an unowned bomb we add it to the group of the player #if there was an unowned bomb we add it to the group of the player
+	if bomb == null: #no bomb hence spawn one
+		bomb = bomb_spawner.spawn([str(requester.name).to_int()])
+	else:
 		bomb.remove_from_group("unowned")
-		bomb.add_to_group(requester.name)
-		return bomb
-	# hence bomb == null which means no bomb is currently unowned and we need to request a new one from the spawner
-	bomb = bomb_spawner.spawn([str(requester.name).to_int()])
+
+	bomb.set_bomb_owner(requester)
 	bomb.add_to_group(requester.name)
 	return bomb
 

--- a/scripts/bomb_root_fsm.gd
+++ b/scripts/bomb_root_fsm.gd
@@ -1,0 +1,80 @@
+#BombRoot is responsible the handle any outside interaction with bombs or in otherwords if any outside object want to interact with a bomb it must call to a function in this file. BombRoot then may or may not change its state if nessessary (hence hand authority to another child node) and give the appropiate information to the appropiate child to handle the interaction.
+extends Node2D
+
+var bomb_owner: Node2D
+
+enum {DISABLED, STATIONARY, AIRBORN, SLIDING, SIZE} #all states plus a SIZE constant that has to remain the last entry
+var state: int = DISABLED #this is the authority if ever somehow two state nodes try to execute text_overrun_behavior
+
+var state_map: Array[Node2D]
+
+func _ready():
+	state_map = [null, get_node("%StationaryBomb"), null, null] 
+	set_state(DISABLED)	
+
+func set_state(choice: int):
+	assert(0 <= choice && choice < SIZE)
+	if state_map[state] != null:
+		state_map[state].disable()#old state should be disabled
+		#state_map[state].set_process(false)
+	state = choice
+
+func disable() -> int:
+	if state == DISABLED:
+		return 1 #it might not be an issue if a disabled node is attempted to be disabled again so we just return an error and let the caller figure that out without giving a project wide error
+	set_state(DISABLED)
+	return 0
+
+func set_bomb_owner(player: Node2D):
+	bomb_owner = player
+
+func do_place(bombPos: Vector2, boost: int):
+	if bomb_owner == null:
+		printerr("A bomb without an bomb_owner tried to be thrown")
+		return 1
+	if state == STATIONARY: #a bomb should not already be in a 
+		printerr("do place is called from a wrong state")
+		return 2
+
+	set_state(STATIONARY)
+	#state_map[state].set_process(true)
+	var bomb_authority: Node2D = state_map[state]
+	bomb_authority.set_explosion_width_and_size(min(boost + bomb_authority.explosion_width, bomb_authority.MAX_EXPLOSION_WIDTH))
+	bomb_authority.pass_bomb_owner()
+	bomb_authority.place(bombPos)
+
+
+#!!!!!
+# ALL FUNCTION FROM THIS POINT ARE EXAMPLES / NOT YET USED BY ANYTHING SO YOU ARE FREE TO COMPLETLY CHANGE THEM IF YOU IMPLEMENT ONE OF THEM PLEASE UPDATE THIS COMMENT TO REFLECT THIS
+#!!!!!
+
+func do_misobon_throw(origin: Vector2, target: Vector2, direction: Vector2i) -> int:
+	if bomb_owner == null: #this should only be called by a misobon player hence the bomb must have an owner
+		printerr("A bomb without an bomb_owner tried to be thrown")
+		return 1
+	if state != DISABLED: #this bomb has should just have been taken from the player pool. if not a fatal error has occured
+		printerr("a misobon player wanted to throw a bomb that already has an active state")
+		return 2
+
+	set_state(AIRBORN)
+	#TODO call the appropiate function to handle this in state_map[state]
+	return 0 #errorcode 0 mean no error
+
+func do_kick(target: Vector2, direction: Vector2i):
+	if bomb_owner == null: #this should only be called by a misobon player hence the bomb must have an owner
+		printerr("A bomb without an bomb_owner tried to be thrown")
+		return 1
+	#TODO make checks for state and change to AIRBORN state if allowed
+	#TODO call the appropiate function to handle this in state_map[state]
+	return 0 #errorcode 0 mean no error
+
+func do_push(direction: Vector2i):
+	if bomb_owner == null: #this should only be called by a misobon player hence the bomb must have an owner
+		printerr("A bomb without an bomb_owner tried to be thrown")
+		return 1
+
+	#TODO make checks for state and change to SLIDING state if allowed
+	#TODO call the appropiate function to handle this in state_map[state]
+	return 0 #errorcode 0 mean no error
+
+#And so on...

--- a/scripts/bomb_root_fsm.gd
+++ b/scripts/bomb_root_fsm.gd
@@ -28,6 +28,7 @@ func disable() -> int:
 func set_bomb_owner(player: Node2D):
 	bomb_owner = player
 
+@rpc("call_local")
 func do_place(bombPos: Vector2, boost: int):
 	if bomb_owner == null:
 		printerr("A bomb without an bomb_owner tried to be thrown")

--- a/scripts/bomb_spawner.gd
+++ b/scripts/bomb_spawner.gd
@@ -5,19 +5,17 @@ extends MultiplayerSpawner
 func _init():
 	spawn_function = _spawn_bomb
 
+#TODO as spawning a bomb does not place it anymore this has to be move to the bomb itself
 func _ready():
 	bomb_placement_sfx_player.set_stream(bomb_audio_stream)
 
 
 func _spawn_bomb(data):
-	if data.size() < 2 or typeof(data[0]) != TYPE_VECTOR2 or typeof(data[1]) != TYPE_INT:
-		push_error("Corrupt data sent to bomb spawner. Bomb not spawned. Output: ", data)
+	if data.size() != 1 or typeof(data[0]) != TYPE_INT:
+		push_error("Corrupt data sent to bomb spawner. Bomb not spawned. data.size():", data.size(), ", data", data)
 		return null
-	bomb_placement_sfx_player.play()
-	var bomb = preload("res://scenes/bomb.tscn").instantiate()
-	bomb.position = data[0]
-	bomb.from_player = data[1]
-	# Increase explosion power by spawning player's boosts
-	if data.size() > 2 and typeof(data[2]) == TYPE_INT:
-		bomb.call_deferred("set_explosion_width_and_size", min(data[2] + bomb.explosion_width, 5))
+	var bomb := preload("res://scenes/bomb/bomb_root.tscn").instantiate()
+	bomb._ready()
+	bomb.set_bomb_owner(get_node("/root/World/Players/" + str(data[0])))
+	bomb.set_state(bomb.DISABLED)
 	return bomb

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -57,13 +57,13 @@ func _physics_process(delta):
 	if not stunned and inputs.bombing and last_bomb_time >= BOMB_RATE:
 		if tileMap != null:
 			bombPos = tileMap.map_to_local(tileMap.local_to_map(synced_position))
-			
+					
 		last_bomb_time = 0.0
 		#take an unused bomb place it and put it into the active bomb bucket
 		print(bomb_queue)
 		var bomb = bomb_queue.pop_front()
-		if bomb != null:
-			bomb.do_place(bombPos, explosion_boost_count)
+		if bomb != null && is_multiplayer_authority():
+			bomb.do_place.rpc(bombPos, explosion_boost_count)
 
 
 	if not stunned:


### PR DESCRIPTION
As discussed on the DC this is an **experimental** change to how we handle bombs
Note: this change needs some serious consideration as its a large change on the workings of a very fundamental part of the game. Also this is not the intended merge, rather is a prototype!

Further note: this branch features all this changes at once, tho we could also only implement a selection.

Change 1: BombPool
The player now does not call on BombSpawner if they need a bomb, but instead request a bomb from the pool. The pool will then returns them a bomb either from the unused pool if there are any or else spawns a new one

Advantages of the BombPool:
- Performance: Memory Allocation is expensive, constantly deleting and instantiating object should be avoided if possible
- Centralized objects that handles all instances of bombs, If information on bombs irrelevant of the player holding them is needed BombPool can take over that task.

Disadvantages of BombPool:
- Memory: While performance may increase holding a bunch of deactivated node trees does cost memory, however the BombRoot object is all things considered fairly small, so even in the worst case (400 afaik instances) this should not be unreasonable
- Complexity: Ofcourse BombPool is a new system and needs to be properly maintained and used.
- (multiplayer syncing) as bombs now change position they need to be synced (I barley count this as for almost all other bomb states / types movement and hence syncing will be needed even in the current system)

Change 2: How the player handles bombs:
The player now holds a list of references to the inactive bombs he holds ownership over in a stack. This also doesn't actually increase the amount of information passed from objects either, mostly just instead of a 32 bit id we pass a 64 bit reference

Advantages:
- Fast access to a players bombs, for modification / pickups and placing
- less abstraction, a player now actively needs a bomb in order to place one rather then rely on an abstract counter

Disadvantages:
- More Bombs: This requires quite a bit more bombs to be held im memory, likely at later stages when players have a large bomb count, but may not use the full extend of it leaving many bombs in memory unused.
- Complexity: The bomb stack needs to be managed which tents to be at least a bit more cumbersome then managing a counter

Change 3: Bomb -> BombRoot
This set up future bomb feature implementations. This adds a Finite state machine layer on top the current bomb that allows for (future) other children that implement different states to function and easily be implemented. I feel the most strongly about this change as I feel continuing with the current implementation of bomb will lead to a mess considering the large amount of features bombs need to fulfill

Advantages:
- Easier time implementing future bomb features, as the implementation can just be a child of BombRoot thats activated and given authority through the BombRoot FSM 
- Clear role distribution, Kinda goes hand in hand with the above point but now BombRoot will handle all calls from the outside of the bomb and assign it to the right child, while the child/state is only responsible for actually performing its state.

Disadvantages:
- Complexity (same as the other two changes)

My own opinion is to keep 1 and 3 and scrap 2, this way we need less bombs in total, and the bomb distribution is more fluent. This comes with the caviat that a bomb potential has to reset more as its owner may change more frequently.

Current issues with this experimental branch:
- [x] Multiplayer: Works on the server side but the client is buggy/struggeling with bomb syncing atm. Need to figure out more about multiplayer to fix this.
- [ ] Bombs are not properly disabled atm while they are inactive. Need to understand process_mode more in order to fix this
- [ ] AI player has not seen changes hence they is no parity between players and aiplayers atm.
- [ ] Place sound effect not yet re implemented
