### PR TITLE
world_data resets on end_game

### DIFF
--- a/autoloads/gamestate.gd
+++ b/autoloads/gamestate.gd
@@ -288,6 +288,7 @@ func end_game():
 	game_ended.emit() 
 	players.clear()
 	resetvars()
+	world_data.reset()
 	
 func resetvars():
 	total_player_count = 1

--- a/autoloads/world_data.gd
+++ b/autoloads/world_data.gd
@@ -156,3 +156,13 @@ func get_random_empty_tiles(count: int, in_cells: bool = false) -> Array:
 	_get_rand_lock.unlock()
 
 	return res
+
+func reset():
+	_is_initialized = false
+	_world_matrix.clear()
+	_world_empty_cells.clear()
+	world_width = 0
+	world_height = 0
+	floor_origin = Vector2i.ZERO	
+	tile_map = null
+


### PR DESCRIPTION
Fixes the issue that a second game cannot be started both in SP and in MP. 