### PR TITLE
implementing hurtboxes and healthloss

### DIFF
--- a/animations/player_animations.tres
+++ b/animations/player_animations.tres
@@ -2,105 +2,6 @@
 
 [ext_resource type="AudioStream" uid="uid://cpniotmerpu5f" path="res://sound/fx/playercrush.wav" id="1_m2tnj"]
 
-[sub_resource type="Animation" id="Animation_cfor6"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("sprite:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [0]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("sprite:self_modulate")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Color(1, 1, 1, 1)]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("kaboom:frame")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [0]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("sprite:visible")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
-}
-tracks/4/type = "value"
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/path = NodePath("kaboom:visible")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/5/type = "value"
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/path = NodePath("shadowsprite:visible")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
-}
-tracks/6/type = "value"
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/path = NodePath(".:stunned")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/7/type = "value"
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/path = NodePath("label:visible")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
-}
-
 [sub_resource type="Animation" id="Animation_mullw"]
 length = 0.2
 tracks/0/type = "audio"
@@ -354,6 +255,21 @@ tracks/3/keys = {
 "values": [Color(0.933537, 0.0630098, 0, 1), Color(0.784314, 0.0784314, 0.239216, 1), Color(1, 1, 1, 1)]
 }
 
+[sub_resource type="Animation" id="Animation_m2tnj"]
+length = 1.6
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("sprite:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0.00833333, 0.2, 0.4, 0.608333, 0.8, 0.991667, 1.19167, 1.4, 1.6),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [0, 16, 11, 18, 0, 16, 11, 18, 0]
+}
+
 [sub_resource type="Animation" id="4"]
 loop_mode = 1
 tracks/0/type = "value"
@@ -465,26 +381,76 @@ tracks/1/keys = {
 "values": [3.14159]
 }
 
-[sub_resource type="Animation" id="Animation_m2tnj"]
-length = 1.6
+[sub_resource type="Animation" id="Animation_23qrq"]
+resource_name = "hurt"
+length = 1.2
+step = 0.125
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("sprite:frame")
+tracks/0/path = NodePath("sprite:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0.00833333, 0.2, 0.4, 0.608333, 0.8, 0.991667, 1.19167, 1.4, 1.6),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1),
-"update": 1,
-"values": [0, 16, 11, 18, 0, 16, 11, 18, 0]
+"times": PackedFloat32Array(0, 0.125, 0.375, 0.625, 0.875, 1.125),
+"transitions": PackedFloat32Array(0.25, 0.25, 1.5, 0.5, 0.5, 1.5),
+"update": 0,
+"values": [Vector2(0.0750351, 6.23615), Vector2(0.075, 8), Vector2(0.075, -40), Vector2(0.075, -25.6726), Vector2(0.075, 4), Vector2(0.075, 2)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("sprite:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.125, 0.375, 0.625, 0.875, 1.125),
+"transitions": PackedFloat32Array(0.25, 0.25, 1.5, 0.5, 0.5, 0.5),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(1, 0.75), Vector2(1, 1.5), Vector2(1, 2), Vector2(1, 0.3), Vector2(1, 0.5)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("label:position")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.125, 0.375, 0.875, 1.125),
+"transitions": PackedFloat32Array(0.25, 1.5, 0.5, 2),
+"update": 0,
+"values": [Vector2(-82, -35), Vector2(-82, -85.236), Vector2(-82, -37.236), Vector2(-82, -37.236)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("sprite:self_modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.75, 0.875, 1.125),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 0, 0, 1), Color(1, 0, 0, 1)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("sprite:rotation")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 0.125, 0.375, 0.625, 1.125),
+"transitions": PackedFloat32Array(1.5, 0.5, 1.5, 0.5, 0.5),
+"update": 0,
+"values": [-6.28319, -6.45772, -2.96706, -3.14159, -3.14159]
 }
 
 [resource]
 _data = {
-&"RESET": SubResource("Animation_cfor6"),
 &"crush": SubResource("Animation_mullw"),
 &"death": SubResource("Animation_ivjsy"),
+&"hurt": SubResource("Animation_23qrq"),
 &"revive": SubResource("Animation_uhsui"),
 &"standing": SubResource("2"),
 &"stunned": SubResource("3"),

--- a/autoloads/gamestate.gd
+++ b/autoloads/gamestate.gd
@@ -200,6 +200,7 @@ func get_player_name():
 	return player_name
 
 func begin_singleplayer_game():
+	globals.current_gamemode = globals.gamemode.CAMPAIGN
 	human_player_count = 1
 	total_player_count = human_player_count
 	if total_player_count > 1:
@@ -210,6 +211,7 @@ func begin_singleplayer_game():
 	load_world.rpc(campaign_game_scene)
 
 func begin_game():
+	globals.current_gamemode = globals.gamemode.BATTLEMODE
 	current_level = 205
 	SettingsContainer.misobon_setting = SettingsContainer.misobon_setting_states.SUPER
 	if players.size() == 0: # If players disconnected at character select

--- a/autoloads/globals.gd
+++ b/autoloads/globals.gd
@@ -1,5 +1,11 @@
 extends Node
 
+enum gamemode {
+	NONE,
+	CAMPAIGN,
+	BATTLEMODE
+}
+
 enum pickups {
 	BOMB_UP = 0,
 	FIRE_UP,
@@ -61,6 +67,7 @@ const DUNGEON_RAND_STAGE_PATH = "res://scenes/stages/dungeon_stages/dungeon_rand
 const LAB_FULL_STAGE_PATH = "res://scenes/stages/lab_stages/lab_full.tscn"
 const LAB_RAND_STAGE_PATH = "res://scenes/stages/lab_stages/lab_rand.tscn"
 
+var current_gamemode := gamemode.NONE
 var config = Config.new()
 var game: Node2D
 var current_world: World

--- a/scenes/enemies/base_enemy_type1.tscn
+++ b/scenes/enemies/base_enemy_type1.tscn
@@ -46,6 +46,14 @@ hframes = 9
 [node name="Hitbox" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_i1su5")
 
+[node name="Hurtbox" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 2
+
+[node name="HurtboxShape" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource("CircleShape2D_i1su5")
+debug_color = Color(1, 0, 0, 0.419608)
+
 [node name="DetectionHandler_A" type="Node2D" parent="."]
 script = ExtResource("5_d2by1")
 

--- a/scenes/enemies/base_enemy_type2.tscn
+++ b/scenes/enemies/base_enemy_type2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://c742ytcwqd1h8"]
+[gd_scene load_steps=15 format=3 uid="uid://c742ytcwqd1h8"]
 
 [ext_resource type="Script" uid="uid://dibr3o26b8gcx" path="res://scripts/enemy/enemy.gd" id="1_vkmfk"]
 [ext_resource type="Texture2D" uid="uid://cpi4w3fgdon0o" path="res://assets/player/playershadow.png" id="2_3i3nn"]
@@ -13,6 +13,9 @@
 [ext_resource type="Texture2D" uid="uid://jog1koyue4lr" path="res://assets/fallingsprite.png" id="10_w272n"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_i1su5"]
+radius = 15.9
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_3i3nn"]
 radius = 15.9
 
 [sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_hwcqj"]
@@ -45,6 +48,14 @@ hframes = 9
 
 [node name="Hitbox" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_i1su5")
+
+[node name="Hurtbox" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 2
+
+[node name="HurtboxShape" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource("CircleShape2D_3i3nn")
+debug_color = Color(1, 0, 0, 0.419608)
 
 [node name="DetectionHandler_B" parent="." groups=["thrown_bomb_bounces"] instance=ExtResource("5_vkmfk")]
 

--- a/scenes/enemies/base_enemy_type3.tscn
+++ b/scenes/enemies/base_enemy_type3.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://c1c607u1xdqs6"]
+[gd_scene load_steps=15 format=3 uid="uid://c1c607u1xdqs6"]
 
 [ext_resource type="Script" uid="uid://dibr3o26b8gcx" path="res://scripts/enemy/enemy.gd" id="1_a7iko"]
 [ext_resource type="Texture2D" uid="uid://cpi4w3fgdon0o" path="res://assets/player/playershadow.png" id="2_ucffh"]
@@ -13,6 +13,9 @@
 [ext_resource type="Texture2D" uid="uid://jog1koyue4lr" path="res://assets/fallingsprite.png" id="10_xqkqv"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_i1su5"]
+radius = 15.9
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_ucffh"]
 radius = 15.9
 
 [sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_hwcqj"]
@@ -45,6 +48,14 @@ hframes = 9
 
 [node name="Hitbox" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_i1su5")
+
+[node name="Hurtbox" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 2
+
+[node name="HurtboxShape" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource("CircleShape2D_ucffh")
+debug_color = Color(1, 0, 0, 0.419608)
 
 [node name="DetectionHandler_C" parent="." groups=["thrown_bomb_bounces"] instance=ExtResource("6_ucffh")]
 

--- a/scenes/enemies/base_enemy_type4.tscn
+++ b/scenes/enemies/base_enemy_type4.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://dge6qedq441yr"]
+[gd_scene load_steps=15 format=3 uid="uid://dge6qedq441yr"]
 
 [ext_resource type="Script" uid="uid://dibr3o26b8gcx" path="res://scripts/enemy/enemy.gd" id="1_8rxir"]
 [ext_resource type="Texture2D" uid="uid://cpi4w3fgdon0o" path="res://assets/player/playershadow.png" id="2_fmktr"]
@@ -13,6 +13,9 @@
 [ext_resource type="Texture2D" uid="uid://jog1koyue4lr" path="res://assets/fallingsprite.png" id="10_tykd3"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_i1su5"]
+radius = 15.9
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_fmktr"]
 radius = 15.9
 
 [sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_hwcqj"]
@@ -46,6 +49,14 @@ hframes = 9
 
 [node name="Hitbox" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_i1su5")
+
+[node name="Hurtbox" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 2
+
+[node name="HurtboxShape" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource("CircleShape2D_fmktr")
+debug_color = Color(1, 0, 0, 0.419608)
 
 [node name="DetectionHandler_D" parent="." instance=ExtResource("5_8rxir")]
 

--- a/scenes/human_player.tscn
+++ b/scenes/human_player.tscn
@@ -47,6 +47,66 @@ tracks/1/keys = {
 "update": 1,
 "values": [0]
 }
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("sprite:position")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0.0750351, 6.23615)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("sprite:scale")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(1, 1)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("label:position")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-82, -35)]
+}
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("sprite:rotation")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [-6.28319]
+}
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("sprite:self_modulate")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_v8ypd"]
 _data = {

--- a/scripts/enemy/enemy.gd
+++ b/scripts/enemy/enemy.gd
@@ -2,9 +2,10 @@ class_name Enemy extends CharacterBody2D
 
 signal enemy_died
 
-@onready var anim_player = $AnimationPlayer
-@onready var statemachine: Node= $StateMachine
-@onready var hitbox = $Hitbox
+@onready var anim_player: AnimationPlayer = $AnimationPlayer
+@onready var statemachine: Node = $StateMachine
+@onready var hitbox: CollisionShape2D = $Hitbox
+@onready var hurtbox: Area2D = $Hurtbox
 
 @export_group("Enemy Settings")
 @export var movement_speed: float = 30.0
@@ -63,6 +64,7 @@ func place(pos: Vector2, path: String):
 	self.enemy_path = path
 
 func enable():
+	self.hurtbox.body_entered.connect(func (player: Player): player.exploded(gamestate.ENVIRONMENTAL_KILL_PLAYER_ID))
 	self.detection_handler.on()
 	self.statemachine.enable()
 
@@ -77,6 +79,8 @@ func disable():
 	if(!is_multiplayer_authority()): return 1
 	hitbox.set_deferred("disabled", 1)
 	hide()
+	for connection in self.hurtbox.body_entered.get_connections():
+		self.hurtbox.body_entered.disconnect(connection.callable)
 	self.position = Vector2.ZERO
 	self.detection_handler.off()
 	self.statemachine.disable()

--- a/scripts/human_player.gd
+++ b/scripts/human_player.gd
@@ -24,20 +24,20 @@ func _physics_process(delta: float):
 	else:
 		# The client simply updates the position to the last known one.
 		position = synced_position
-	if not stunned and inputs.punch_ability and not punch_pressed_once and not is_victory_dance:
+	if not stunned and inputs.punch_ability and not punch_pressed_once and not stop_movement:
 		punch_pressed_once = true
 		var direction: Vector2i = Vector2i(inputs.motion.normalized()) if inputs.motion != Vector2.ZERO else Vector2i.DOWN
 		punch_bomb(direction)
 	elif !inputs.punch_ability and punch_pressed_once:
 		punch_pressed_once = false
 
-	if not stunned and inputs.bombing and bomb_count > 0 and not set_bomb_pressed_once and not is_victory_dance:
+	if not stunned and inputs.bombing and bomb_count > 0 and not set_bomb_pressed_once and not stop_movement:
 		set_bomb_pressed_once = true
 		place_bomb()
 	elif !inputs.bombing and set_bomb_pressed_once:
 		set_bomb_pressed_once = false
 
-	if !is_dead && !stunned && !is_victory_dance:
+	if !is_dead && !stunned && !stop_movement:
 		# Everybody runs physics. I.e. clients tries to predict where they will be during the next frame.
 		velocity = inputs.motion.normalized() * movement_speed
 		move_and_slide()

--- a/scripts/players_manager.gd
+++ b/scripts/players_manager.gd
@@ -24,7 +24,6 @@ func _on_player_died():
 func _on_player_revived():
 	players_left += 1
 
-
 func _on_hurry_up_start() -> void:
 	if SettingsContainer.misobon_setting == SettingsContainer.misobon_setting_states.OFF:
 		return

--- a/scripts/world/world.gd
+++ b/scripts/world/world.gd
@@ -96,7 +96,7 @@ func enable(
 	all_enemied_died.connect(globals.game._check_ending_condition, CONNECT_ONE_SHOT)
 
 
-	if hurry_up: ##SP stages may not have a hurry up node
+	if hurry_up && globals.current_gamemode != globals.gamemode.CAMPAIGN:
 		hurry_up.start()
 
 	_exit_spawned_barrier = false
@@ -226,7 +226,7 @@ func _set_spawnpoints():
 		remaining_spawnpoints -= 1
 
 @rpc("call_local")
-## places players (assumes players already exist
+## places players (assumes players already exist)
 func _place_players():
 	# Create a dictionary with peer id and respective spawn points, could be improved by randomizing.
 	var spawn_points = {}


### PR DESCRIPTION
Implements hurtboxes to enemies and gives the player an animation when he gets hurt (looses health but health not 0) that works like in SB5. Hence re-spawning the player at its spawn-point with invulnerability after getting hurt.
Also adds an enum to differentiate gamemodes and branches some behavior off of it like:
Spread items and hurry up only in Battle mode 