### PR TITLE
Fixed music playing in menu before settings loaded

### DIFF
--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -101,7 +101,6 @@ offset_bottom = -317.0
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("10_5dd4i")
-autoplay = true
 bus = &"Music"
 parameters/looping = true
 

--- a/scripts/ui/main_menu.gd
+++ b/scripts/ui/main_menu.gd
@@ -8,8 +8,10 @@ signal options_menu_entered
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	main_menu_music_player.play()
+	main_menu_music_player.autoplay = true
 	$ButtonBox/Singleplayer.grab_focus()
-	
+
 func switch_to_options_menu() -> void:
 	hide_main_menu()
 	options_menu.visible = true


### PR DESCRIPTION
If you turn off music volume all the way to zero in options and restart the game, first few frames it will blast on full (aka BIG "BOP"). This happens due to autoplay is on by default and music starts playing before settings loaded. Turning off autoplay and start playing music on _ready fixes this behaviour.