### PR TITLE
Saves-, Character- and Name selection

### DIFF
--- a/autoloads/campaign_save_manager.gd
+++ b/autoloads/campaign_save_manager.gd
@@ -1,0 +1,59 @@
+extends Node
+
+signal has_saved(file: String)
+signal has_loaded(file: String)
+
+const SAVE_PATH: String = "user://save_data"
+const EMPTY_SAVE: Dictionary = {
+	"campaign": "",
+	"campaign_version": LevelGraph.VERSION,
+	"player_name": "Player1",
+	"character_paths": {},
+	"player_health": 3,
+	"player_pickups": {},
+	"last_stage": 0,
+	"visited_exits": [], # contains dicts with {"stage": x, "exit": [x]} of exits that have already been visited in this safe
+	"current_score": 0,
+	"completion": 0.0,
+	"has_finished": false,
+	}
+
+func save(data: Dictionary, file_name: String) -> void:
+	if !FileAccess.file_exists(SAVE_PATH):
+		DirAccess.make_dir_recursive_absolute(SAVE_PATH)
+
+	var file_access := FileAccess.open(SAVE_PATH + "/" + file_name + ".json", FileAccess.WRITE)
+	if not file_access:
+		print("An error happened while saving data: ", FileAccess.get_open_error())
+		return
+	file_access.store_line(JSON.stringify(data))
+	file_access.close()
+	has_saved.emit(file_name)
+
+func delete_save(file_name: String) -> void:
+	if !FileAccess.file_exists(SAVE_PATH + "/" + file_name + ".json"):
+		push_error("attempted to delete a nonexisting save: " + file_name + ".json")
+		return
+	DirAccess.remove_absolute(SAVE_PATH + "/" + file_name + ".json")
+
+func save_exist(file_name: String) -> bool:
+	return FileAccess.file_exists(SAVE_PATH + "/" + file_name + ".json")
+
+func load(file_name: String) -> Dictionary:
+	if !FileAccess.file_exists(SAVE_PATH + "/" + file_name + ".json"):
+		push_error("attempted to load a nonexisting save: " + file_name + ".json")
+		return EMPTY_SAVE.duplicate()
+	var file_access := FileAccess.open(SAVE_PATH + "/" + file_name + ".json", FileAccess.READ)
+	var json_string := file_access.get_line()
+	file_access.close()
+
+	var json: JSON = JSON.new()
+	var error := json.parse(json_string)
+	if error:
+		print("JSON Parse Error: ", json.get_error_message(), " in ", json_string, " at line ", json.get_error_line())
+		return EMPTY_SAVE.duplicate()
+	return json.data
+
+func get_new_save() -> Dictionary:
+	return EMPTY_SAVE.duplicate()
+	

--- a/autoloads/campaign_save_manager.gd.uid
+++ b/autoloads/campaign_save_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://dunq42xj61qhu

--- a/autoloads/gamestate.gd
+++ b/autoloads/gamestate.gd
@@ -35,6 +35,7 @@ var DEFAULT_PLAYER_TEXTURE_PATH = character_texture_paths.NORMALGOON_PLAYER_TEXT
 # is_ai - 
 # is_enabled - determines if the player actually is loaded in or if their slot is available
 
+
 var player_data_resource: PlayerDataResource = preload("res://resources/settings/player_data_default.tres")
 var player_data_master_dict = {
 	1: {
@@ -68,6 +69,9 @@ var battlemode_game_scene: String = "res://scenes/battlemode_game.tscn"
 
 # Singleplayer Vars
 var current_level: int = 1 #205 # Defaults to a high number for battle mode.
+var current_save_file: String = ""
+var current_save: Dictionary
+var current_graph: String
 
 # Battle Mode vars
 
@@ -231,8 +235,8 @@ func load_world(game_scene):
 	# Change scene.
 	var game = load(game_scene).instantiate()
 	get_tree().get_root().add_child(game)
-	if has_node("/root/MainMenu/DebugCampaignSelector"):
-		game.load_level_graph(get_node("/root/MainMenu/DebugCampaignSelector").get_graph())
+	if globals.current_gamemode == globals.gamemode.CAMPAIGN:
+		game.load_level_graph(current_graph)
 	if has_node("/root/MainMenu"):
 		get_node("/root/MainMenu").pause_main_menu_music()
 
@@ -297,10 +301,13 @@ func begin_singleplayer_game():
 	SettingsContainer.misobon_setting = SettingsContainer.misobon_setting_states.OFF
 	human_player_count = 1
 	total_player_count = human_player_count
+	# only used for spawning ai to debug
 	if total_player_count > 1:
 		add_ai_players(total_player_count - human_player_count)
 
-	player_data_master_dict[1].spritepaths = character_texture_paths.bhdoki_paths
+	player_name = current_save.player_name
+	player_data_master_dict[1].playername = current_save.player_name
+	player_data_master_dict[1].spritepaths = current_save.character_paths
 	load_world.rpc(campaign_game_scene)
 
 func begin_game():
@@ -386,15 +393,19 @@ func is_name_free(playername: String) -> bool:
 	return true
 			
 func end_sp_game():
+	campaign_save_manager.save(current_save, current_save_file)
 	if globals.game != null: # Game is in progress.
 		# End it
 		globals.game.queue_free()
 	await get_tree().create_timer(0.05).timeout #The game scene needs to DIE.
-	#Only run if Main Menu is currently loaded in the scene.
+	# Only run if Main Menu is currently loaded in the scene.
 	if has_node("/root/MainMenu"):
 		var main_menu = get_node("/root/MainMenu")
 		main_menu.show()
 		main_menu.unpause_main_menu_music()
+	elif has_node("/root/lobby"):
+		var lobby: Node2D = get_node("/root/lobby")
+		lobby.get_back_to_menu()
 	game_ended.emit() #Listen to this signal to tell other nodes to cease the game.
 	player_data_master_dict.clear()
 	resetvars()

--- a/autoloads/gamestate.gd
+++ b/autoloads/gamestate.gd
@@ -236,6 +236,8 @@ func load_world(game_scene):
 	var game = load(game_scene).instantiate()
 	get_tree().get_root().add_child(game)
 	if globals.current_gamemode == globals.gamemode.CAMPAIGN:
+		if self.current_save.campaign != "": current_graph = self.current_save.campaign
+		else: self.current_save.campaign = current_graph
 		game.load_level_graph(current_graph)
 	if has_node("/root/MainMenu"):
 		get_node("/root/MainMenu").pause_main_menu_music()
@@ -392,8 +394,11 @@ func is_name_free(playername: String) -> bool:
 		return false
 	return true
 			
-func end_sp_game():
+func save_sp_game():
 	campaign_save_manager.save(current_save, current_save_file)
+
+func end_sp_game():
+	save_sp_game()
 	if globals.game != null: # Game is in progress.
 		# End it
 		globals.game.queue_free()

--- a/project.godot
+++ b/project.godot
@@ -109,6 +109,11 @@ pause={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
+toggle_debug={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/project.godot
+++ b/project.godot
@@ -28,6 +28,7 @@ SettingsSignalBus="*res://autoloads/settings_signal_bus.gd"
 SettingsContainer="*res://autoloads/settings_data_container.gd"
 SaveManager="*res://autoloads/save_manager.gd"
 AudioManager="*res://autoloads/audio_manager.gd"
+campaign_save_manager="*res://autoloads/campaign_save_manager.gd"
 
 [display]
 

--- a/resources/gameplay/pickup_table.gd
+++ b/resources/gameplay/pickup_table.gd
@@ -17,7 +17,7 @@ const PICKUP_SPAWN_BASE_CHANCE: float = 1.0
 @export var wallthrough: int = 50
 @export var timer: int = 10
 @export var invincibility_vest: int = 50
-@export var virus: int = 500
+@export var virus: int = 50
 @export var kick: int = 50
 @export var bombthrough: int = 50
 @export var piercing_bomb: int = 50
@@ -147,8 +147,17 @@ func to_json() -> Dictionary:
 	return {"weights": pickup_weights, "are_amounts": are_amounts, "base_pickup_spawn_chance": base_pickup_spawn_chance}
 
 func from_json(tabel: Dictionary):
-	for key in tabel.weights.keys():
-		self.pickup_weights[int(key)] = tabel.weights[key]
+	for pickup in range(globals.pickups.NONE):
+		match pickup:
+			globals.pickups.GENERIC_COUNT: continue
+			globals.pickups.GENERIC_BOOL: continue
+			globals.pickups.GENERIC_EXCLUSIVE: continue
+			globals.pickups.GENERIC_BOMB: continue
+
+		if tabel.weights.has(str(pickup)):
+			self.pickup_weights[pickup] = tabel.weights[str(pickup)]
+		else: 
+			self.pickup_weights[pickup] = 0
 	self.reverse_update()
 	self.is_uptodate = true
 	self.are_amounts = tabel.are_amounts

--- a/resources/settings/player_keybind_default.tres
+++ b/resources/settings/player_keybind_default.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="PlayerKeybindResource" load_steps=11 format=3 uid="uid://3ychjvba1m30"]
 
-[ext_resource type="Script" uid="uid://coe104tvl5rqq" path="res://resources/settings/player_keybind_resource.gd" id="1_t20qs"]
+[ext_resource type="Script" uid="uid://ct2o5aqdn4oiv" path="res://resources/settings/player_keybind_resource.gd" id="1_t20qs"]
 
 [sub_resource type="InputEventKey" id="InputEventKey_bq1eo"]
 device = -1

--- a/scenes/campaign_game.tscn
+++ b/scenes/campaign_game.tscn
@@ -206,3 +206,4 @@ metadata/_edit_use_anchors_ = true
 
 [connection signal="clock_pickup_time_paused" from="." to="." method="pause_time"]
 [connection signal="clock_pickup_time_unpaused" from="." to="." method="unpause_time"]
+[connection signal="score_updated" from="." to="CampaignGameUI" method="update_score"]

--- a/scenes/cssmenu/sp_character_select_button_group.tres
+++ b/scenes/cssmenu/sp_character_select_button_group.tres
@@ -1,0 +1,3 @@
+[gd_resource type="ButtonGroup" format=3 uid="uid://d1505t6ofb1nv"]
+
+[resource]

--- a/scenes/cssmenu/sp_character_select_screen.tscn
+++ b/scenes/cssmenu/sp_character_select_screen.tscn
@@ -1,0 +1,456 @@
+[gd_scene load_steps=19 format=3 uid="uid://cwhum362lt6ww"]
+
+[ext_resource type="Script" uid="uid://diwfw63wskeam" path="res://scripts/ui/cssmenu/sp_character_select_screen.gd" id="1_m7566"]
+[ext_resource type="Theme" uid="uid://bgj72vffexht" path="res://assets/styles/panel_theme.tres" id="3_5sbwn"]
+[ext_resource type="ButtonGroup" uid="uid://d1505t6ofb1nv" path="res://scenes/cssmenu/sp_character_select_button_group.tres" id="3_m7566"]
+[ext_resource type="Texture2D" uid="uid://dc6n600vfnmgp" path="res://assets/css/eggoon.png" id="4_dhy2l"]
+[ext_resource type="Texture2D" uid="uid://bb8yee4kwa6dt" path="res://assets/css/normalgoon.png" id="5_5yoqc"]
+[ext_resource type="Texture2D" uid="uid://d3cn5or0vkn23" path="res://assets/css/chonkgoon.png" id="6_8ct70"]
+[ext_resource type="Texture2D" uid="uid://cqgmyjw0vef1" path="res://assets/css/longgoon.png" id="7_yavy2"]
+[ext_resource type="Texture2D" uid="uid://x3kkdsn6q0cj" path="res://assets/css/dad.png" id="8_fameb"]
+[ext_resource type="Texture2D" uid="uid://che0qovasljj7" path="res://assets/css/bhdoki.png" id="9_gox0l"]
+[ext_resource type="Texture2D" uid="uid://bnedjf17yf4un" path="res://assets/css/retrodoki.png" id="10_48vj3"]
+[ext_resource type="Texture2D" uid="uid://d0y2r3fljtvvk" path="res://assets/css/altdoki.png" id="11_cwf8a"]
+[ext_resource type="Texture2D" uid="uid://bcm64uj7bwp87" path="res://assets/css/crowki.png" id="12_yf0se"]
+[ext_resource type="Texture2D" uid="uid://bpx3jen13addh" path="res://assets/css/tomato.png" id="13_bx7t6"]
+[ext_resource type="Texture2D" uid="uid://cefndan5pti47" path="res://assets/css/wisp.png" id="14_dj41s"]
+[ext_resource type="Texture2D" uid="uid://bngq754xh3q18" path="res://assets/css/maidmint.png" id="15_y4rb0"]
+[ext_resource type="AudioStream" uid="uid://cb75c45y5yhvk" path="res://sound/fx/click.wav" id="16_41akf"]
+[ext_resource type="Script" uid="uid://boq3i75yls51h" path="res://scripts/ui/ingame_ui/se_button.gd" id="17_sdw0t"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_m7566"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.960784, 0.827451, 0.109804, 1)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+
+[node name="CharacterSelectScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 2.0
+offset_right = 1154.0
+offset_bottom = 648.0
+script = ExtResource("1_m7566")
+
+[node name="CSSLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -288.5
+offset_right = 288.5
+offset_bottom = 69.0
+grow_horizontal = 2
+theme = ExtResource("3_5sbwn")
+theme_override_font_sizes/font_size = 75
+text = "CHOOSE YOUR CHARACTER"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="SkinBG" type="PanelContainer" parent="."]
+texture_filter = 3
+layout_mode = 0
+offset_left = 90.0
+offset_top = 104.0
+offset_right = 746.0
+offset_bottom = 376.0
+theme = ExtResource("3_5sbwn")
+
+[node name="CharacterGrid" type="GridContainer" parent="SkinBG"]
+unique_name_in_owner = true
+texture_filter = 1
+layout_mode = 2
+columns = 5
+
+[node name="eggoon" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("4_dhy2l")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/eggoon"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="dragoon" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("5_5yoqc")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/dragoon"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="chonkgoon" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("6_8ct70")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/chonkgoon"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="longoon" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("7_yavy2")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/longoon"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="dad" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("8_fameb")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/dad"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="bhdoki" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("9_gox0l")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/bhdoki"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="retrodoki" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("10_48vj3")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/retrodoki"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="altdoki" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("11_cwf8a")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/altdoki"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="crowki" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("12_yf0se")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/crowki"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="tomato" type="TextureButton" parent="SkinBG/CharacterGrid"]
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("13_bx7t6")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/tomato"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="secret1" type="TextureButton" parent="SkinBG/CharacterGrid"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("14_dj41s")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/secret1"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="secret2" type="TextureButton" parent="SkinBG/CharacterGrid"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+toggle_mode = true
+button_group = ExtResource("3_m7566")
+texture_normal = ExtResource("15_y4rb0")
+stretch_mode = 0
+
+[node name="Panel" type="Panel" parent="SkinBG/CharacterGrid/secret2"]
+visible = false
+show_behind_parent = true
+z_as_relative = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_right = 2.0
+offset_bottom = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_m7566")
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("16_41akf")
+bus = &"SFX"
+
+[node name="Start" type="Button" parent="." groups=["ui_button"]]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = 239.0
+offset_top = -373.0
+offset_right = 479.0
+offset_bottom = -309.0
+grow_horizontal = 2
+grow_vertical = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+theme = ExtResource("3_5sbwn")
+theme_override_font_sizes/font_size = 46
+text = "Start"
+script = ExtResource("17_sdw0t")
+metadata/_custom_type_script = "uid://boq3i75yls51h"
+
+[node name="Exit" type="Button" parent="." groups=["ui_button"]]
+layout_mode = 0
+offset_left = 542.0
+offset_top = 600.0
+offset_right = 620.0
+offset_bottom = 638.0
+focus_neighbor_top = NodePath("../Multiplayer")
+focus_neighbor_bottom = NodePath("../SinglePlayer")
+theme = ExtResource("3_5sbwn")
+theme_override_colors/font_focus_color = Color(1, 0, 0, 1)
+text = "Back"
+script = ExtResource("17_sdw0t")
+metadata/_custom_type_script = "uid://boq3i75yls51h"
+
+[node name="PlayerList" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 235.0
+offset_top = -219.0
+offset_right = 487.0
+offset_bottom = -111.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 2
+size_flags_vertical = 2
+theme = ExtResource("3_5sbwn")
+
+[node name="Label" type="Label" parent="PlayerList"]
+layout_mode = 0
+offset_left = 26.0
+offset_top = 7.0
+offset_right = 229.0
+offset_bottom = 30.0
+size_flags_horizontal = 2
+size_flags_vertical = 0
+theme_override_font_sizes/font_size = 35
+text = "NAME"
+horizontal_alignment = 1
+
+[node name="PlayerName" type="LineEdit" parent="PlayerList"]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 25.0
+offset_top = 45.0
+offset_right = 229.0
+offset_bottom = 91.0
+theme = ExtResource("3_5sbwn")
+theme_override_font_sizes/font_size = 35
+placeholder_text = "Player1"
+max_length = 12
+emoji_menu_enabled = false
+
+[connection signal="pressed" from="SkinBG/CharacterGrid/eggoon" to="." method="_on_eggoon_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/dragoon" to="." method="_on_dragoon_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/chonkgoon" to="." method="_on_chonkgoon_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/longoon" to="." method="_on_longoon_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/dad" to="." method="_on_dad_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/bhdoki" to="." method="_on_bhdoki_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/retrodoki" to="." method="_on_retrodoki_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/altdoki" to="." method="_on_altdoki_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/crowki" to="." method="_on_crowki_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/tomato" to="." method="_on_tomato_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/secret1" to="." method="_on_secret_1_pressed"]
+[connection signal="pressed" from="SkinBG/CharacterGrid/secret2" to="." method="_on_secret_2_pressed"]
+[connection signal="pressed" from="Start" to="." method="_on_confirm_pressed"]
+[connection signal="pressed" from="Exit" to="." method="_on_exit_pressed"]
+[connection signal="text_changed" from="PlayerList/PlayerName" to="." method="_on_player_name_text_changed"]

--- a/scenes/cssmenu/sp_character_select_screen.tscn
+++ b/scenes/cssmenu/sp_character_select_screen.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://cwhum362lt6ww"]
+[gd_scene load_steps=22 format=3 uid="uid://cwhum362lt6ww"]
 
 [ext_resource type="Script" uid="uid://diwfw63wskeam" path="res://scripts/ui/cssmenu/sp_character_select_screen.gd" id="1_m7566"]
 [ext_resource type="Theme" uid="uid://bgj72vffexht" path="res://assets/styles/panel_theme.tres" id="3_5sbwn"]
@@ -17,6 +17,9 @@
 [ext_resource type="Texture2D" uid="uid://bngq754xh3q18" path="res://assets/css/maidmint.png" id="15_y4rb0"]
 [ext_resource type="AudioStream" uid="uid://cb75c45y5yhvk" path="res://sound/fx/click.wav" id="16_41akf"]
 [ext_resource type="Script" uid="uid://boq3i75yls51h" path="res://scripts/ui/ingame_ui/se_button.gd" id="17_sdw0t"]
+[ext_resource type="FontFile" uid="uid://knb8u535cfkw" path="res://montserrat.otf" id="18_bappc"]
+[ext_resource type="PackedScene" uid="uid://c7x6djajavw8b" path="res://scenes/debug_campaign_selector.tscn" id="19_dhy2l"]
+[ext_resource type="Theme" uid="uid://d2oqlxohwao3c" path="res://assets/styles/battle_settings_menu.tres" id="20_5yoqc"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_m7566"]
 bg_color = Color(0.6, 0.6, 0.6, 0)
@@ -434,10 +437,19 @@ offset_top = 45.0
 offset_right = 229.0
 offset_bottom = 91.0
 theme = ExtResource("3_5sbwn")
+theme_override_fonts/font = ExtResource("18_bappc")
 theme_override_font_sizes/font_size = 35
 placeholder_text = "Player1"
 max_length = 12
 emoji_menu_enabled = false
+
+[node name="DebugCampaignSelector" parent="." instance=ExtResource("19_dhy2l")]
+layout_mode = 1
+offset_left = 223.0
+offset_top = 404.0
+offset_right = 223.0
+offset_bottom = 404.0
+theme = ExtResource("20_5yoqc")
 
 [connection signal="pressed" from="SkinBG/CharacterGrid/eggoon" to="." method="_on_eggoon_pressed"]
 [connection signal="pressed" from="SkinBG/CharacterGrid/dragoon" to="." method="_on_dragoon_pressed"]

--- a/scenes/debug_campaign_selector.tscn
+++ b/scenes/debug_campaign_selector.tscn
@@ -5,11 +5,7 @@
 
 [node name="DebugCampaignSelector" type="Control"]
 layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
 script = ExtResource("1_ax5x0")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]

--- a/scenes/debug_campaign_selector.tscn
+++ b/scenes/debug_campaign_selector.tscn
@@ -28,4 +28,5 @@ text = "Graph"
 script = ExtResource("2_h4g6p")
 metadata/_custom_type_script = "uid://boq3i75yls51h"
 
+[connection signal="item_selected" from="HBoxContainer/CampaignSelector" to="." method="_on_campaign_selector_item_selected"]
 [connection signal="pressed" from="HBoxContainer/GraphButton" to="." method="_on_graph_button_pressed"]

--- a/scenes/enemies/alt_doki_boss.tscn
+++ b/scenes/enemies/alt_doki_boss.tscn
@@ -26,6 +26,7 @@
 script = ExtResource("2_6ojfo")
 initial_bomb_type = 0
 initial_exlusive = 0
+initial_virus = 0
 initial_bomb_up = 4
 initial_fire_up = 6
 initial_speed_up = 2

--- a/scenes/enemies/mint_boss.tscn
+++ b/scenes/enemies/mint_boss.tscn
@@ -25,6 +25,7 @@
 script = ExtResource("2_8i32n")
 initial_bomb_type = 1
 initial_exlusive = 2
+initial_virus = 0
 initial_bomb_up = 3
 initial_fire_up = 0
 initial_speed_up = 0
@@ -105,6 +106,7 @@ texture_filter = 1
 collision_layer = 32
 collision_mask = 13
 script = ExtResource("1_dpfu0")
+is_secret_boss = true
 pickups = SubResource("Resource_cvltp")
 ability_detector = NodePath("AbilityDetector")
 dropped_pickup = "punch_ability"

--- a/scenes/lobby/save_button_groups.tres
+++ b/scenes/lobby/save_button_groups.tres
@@ -1,0 +1,3 @@
+[gd_resource type="ButtonGroup" format=3 uid="uid://byiqy0nc66oad"]
+
+[resource]

--- a/scenes/lobby/save_select.tscn
+++ b/scenes/lobby/save_select.tscn
@@ -1,0 +1,256 @@
+[gd_scene load_steps=6 format=3 uid="uid://mjnlboref67"]
+
+[ext_resource type="Theme" uid="uid://bgj72vffexht" path="res://assets/styles/panel_theme.tres" id="1_4trsy"]
+[ext_resource type="Script" uid="uid://b4vallsu2hqgv" path="res://scripts/ui/lobby/save_menu.gd" id="1_5k5kr"]
+[ext_resource type="Script" uid="uid://boq3i75yls51h" path="res://scripts/ui/ingame_ui/se_button.gd" id="2_3frgu"]
+[ext_resource type="PackedScene" uid="uid://bxuaysj7k43qf" path="res://scenes/lobby/save_select_button_left.tscn" id="3_3frgu"]
+[ext_resource type="PackedScene" uid="uid://ckjwenucikdus" path="res://scenes/lobby/save_select_button_right.tscn" id="3_g44e4"]
+
+[node name="SaveMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_5k5kr")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 0.95
+anchor_right = 0.5
+anchor_bottom = 0.95
+offset_left = -145.5
+offset_top = -51.0
+offset_right = 145.5
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_constants/separation = 160
+alignment = 1
+
+[node name="Next" type="Button" parent="HBoxContainer" node_paths=PackedStringArray("shortcut_context") groups=["ui_button"]]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_horizontal = 2
+size_flags_vertical = 2
+focus_neighbor_left = NodePath("../Back")
+focus_neighbor_top = NodePath("../../Saves/Left/SaveSelectButton_3")
+focus_neighbor_right = NodePath("../Delete")
+focus_neighbor_bottom = NodePath("../../Saves/Left/SaveSelectButton_1")
+focus_next = NodePath("../Delete")
+focus_previous = NodePath("../../Saves/Right/SaveSelectButton_6")
+shortcut_context = NodePath("../Delete")
+theme = ExtResource("1_4trsy")
+theme_override_font_sizes/font_size = 46
+text = "Next
+"
+script = ExtResource("2_3frgu")
+metadata/_custom_type_script = "uid://boq3i75yls51h"
+
+[node name="Delete" type="Button" parent="HBoxContainer" node_paths=PackedStringArray("shortcut_context") groups=["ui_button"]]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_horizontal = 2
+size_flags_vertical = 2
+focus_neighbor_left = NodePath("../Next")
+focus_neighbor_top = NodePath("../../Saves/Left/SaveSelectButton_3")
+focus_neighbor_right = NodePath("../Back")
+focus_neighbor_bottom = NodePath("../../Saves/Left/SaveSelectButton_1")
+focus_next = NodePath("../Back")
+focus_previous = NodePath("../Next")
+shortcut_context = NodePath("../Back")
+theme = ExtResource("1_4trsy")
+theme_override_font_sizes/font_size = 46
+text = "Delete"
+script = ExtResource("2_3frgu")
+metadata/_custom_type_script = "uid://boq3i75yls51h"
+
+[node name="Back" type="Button" parent="HBoxContainer" node_paths=PackedStringArray("shortcut_context") groups=["ui_button"]]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_horizontal = 2
+size_flags_vertical = 2
+focus_neighbor_left = NodePath("../Delete")
+focus_neighbor_top = NodePath("../../Saves/Right/SaveSelectButton_6")
+focus_neighbor_right = NodePath("../Next")
+focus_neighbor_bottom = NodePath("../../Saves/Right/SaveSelectButton_4")
+focus_next = NodePath("../../Saves/Left/SaveSelectButton_1")
+focus_previous = NodePath("../Delete")
+shortcut_context = NodePath("../../Saves/Left/SaveSelectButton_1")
+theme = ExtResource("1_4trsy")
+theme_override_font_sizes/font_size = 46
+text = "Back"
+icon_alignment = 1
+script = ExtResource("2_3frgu")
+metadata/_custom_type_script = "uid://boq3i75yls51h"
+
+[node name="SaveLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -288.5
+offset_right = 288.5
+offset_bottom = 69.0
+grow_horizontal = 2
+theme = ExtResource("1_4trsy")
+theme_override_font_sizes/font_size = 75
+text = "SELECT A SAVE"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Saves" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 14
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Left" type="Control" parent="Saves"]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_top = -160.0
+offset_right = 400.0
+offset_bottom = 160.0
+grow_vertical = 2
+
+[node name="SaveSelectButton_1" parent="Saves/Left" node_paths=PackedStringArray("shortcut_context") instance=ExtResource("3_g44e4")]
+unique_name_in_owner = true
+layout_mode = 1
+focus_neighbor_left = NodePath("../../Right/SaveSelectButton_4")
+focus_neighbor_top = NodePath("../../../HBoxContainer/Next")
+focus_neighbor_right = NodePath("../../Right/SaveSelectButton_4")
+focus_neighbor_bottom = NodePath("../SaveSelectButton_2")
+focus_next = NodePath("../SaveSelectButton_2")
+focus_previous = NodePath("../../Right/SaveSelectButton_6")
+shortcut_context = NodePath("../SaveSelectButton_2")
+
+[node name="SaveSelectButton_2" parent="Saves/Left" node_paths=PackedStringArray("shortcut_context") instance=ExtResource("3_g44e4")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_top = -40.0
+offset_bottom = 40.0
+grow_vertical = 2
+focus_neighbor_left = NodePath("../../Right/SaveSelectButton_5")
+focus_neighbor_top = NodePath("../SaveSelectButton_1")
+focus_neighbor_right = NodePath("../../Right/SaveSelectButton_5")
+focus_neighbor_bottom = NodePath("../SaveSelectButton_3")
+focus_next = NodePath("../SaveSelectButton_3")
+focus_previous = NodePath("../SaveSelectButton_1")
+shortcut_context = NodePath("../SaveSelectButton_3")
+
+[node name="SaveSelectButton_3" parent="Saves/Left" node_paths=PackedStringArray("shortcut_context") instance=ExtResource("3_g44e4")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -80.0
+offset_bottom = 0.0
+grow_vertical = 0
+focus_neighbor_left = NodePath("../../Right/SaveSelectButton_6")
+focus_neighbor_top = NodePath("../SaveSelectButton_2")
+focus_neighbor_right = NodePath("../../Right/SaveSelectButton_6")
+focus_neighbor_bottom = NodePath("../../../HBoxContainer/Next")
+focus_next = NodePath("../../Right/SaveSelectButton_4")
+focus_previous = NodePath("../SaveSelectButton_2")
+shortcut_context = NodePath("../../Right/SaveSelectButton_4")
+
+[node name="Right" type="Control" parent="Saves"]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -400.0
+offset_top = -160.0
+offset_bottom = 160.0
+grow_horizontal = 0
+grow_vertical = 2
+
+[node name="SaveSelectButton_4" parent="Saves/Right" node_paths=PackedStringArray("shortcut_context") instance=ExtResource("3_3frgu")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -400.0
+offset_right = 0.0
+grow_horizontal = 0
+focus_neighbor_left = NodePath("../../Left/SaveSelectButton_1")
+focus_neighbor_top = NodePath("../../../HBoxContainer/Back")
+focus_neighbor_right = NodePath("../../Left/SaveSelectButton_1")
+focus_neighbor_bottom = NodePath("../SaveSelectButton_5")
+focus_next = NodePath("../SaveSelectButton_5")
+focus_previous = NodePath("../../Left/SaveSelectButton_3")
+shortcut_context = NodePath("../SaveSelectButton_5")
+
+[node name="SaveSelectButton_5" parent="Saves/Right" node_paths=PackedStringArray("shortcut_context") instance=ExtResource("3_3frgu")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -400.0
+offset_top = -40.0
+offset_right = 0.0
+offset_bottom = 40.0
+grow_horizontal = 0
+grow_vertical = 2
+focus_neighbor_left = NodePath("../../Left/SaveSelectButton_2")
+focus_neighbor_top = NodePath("../SaveSelectButton_4")
+focus_neighbor_right = NodePath("../../Left/SaveSelectButton_2")
+focus_neighbor_bottom = NodePath("../SaveSelectButton_6")
+focus_next = NodePath("../SaveSelectButton_6")
+focus_previous = NodePath("../SaveSelectButton_4")
+shortcut_context = NodePath("../SaveSelectButton_6")
+
+[node name="SaveSelectButton_6" parent="Saves/Right" node_paths=PackedStringArray("shortcut_context") instance=ExtResource("3_3frgu")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -400.0
+offset_top = -80.0
+offset_right = 0.0
+offset_bottom = 0.0
+grow_horizontal = 0
+grow_vertical = 0
+focus_neighbor_left = NodePath("../../Left/SaveSelectButton_3")
+focus_neighbor_top = NodePath("../SaveSelectButton_5")
+focus_neighbor_right = NodePath("../../Left/SaveSelectButton_3")
+focus_neighbor_bottom = NodePath("../../../HBoxContainer/Back")
+focus_next = NodePath("../../../HBoxContainer/Next")
+focus_previous = NodePath("../SaveSelectButton_5")
+shortcut_context = NodePath("../../../HBoxContainer/Next")
+
+[node name="ConfirmationDialog" type="ConfirmationDialog" parent="."]
+size = Vector2i(344, 100)
+ok_button_text = "Yes"
+dialog_text = "Are your sure you with to delete this save?"
+dialog_autowrap = true
+cancel_button_text = "No"
+
+[connection signal="pressed" from="HBoxContainer/Next" to="." method="_on_next_pressed"]
+[connection signal="pressed" from="HBoxContainer/Delete" to="." method="_on_delete_pressed"]
+[connection signal="pressed" from="HBoxContainer/Back" to="." method="_on_back_pressed"]
+[connection signal="canceled" from="ConfirmationDialog" to="." method="_on_delete_cancelled"]
+[connection signal="confirmed" from="ConfirmationDialog" to="." method="_on_delete_confirmed"]

--- a/scenes/lobby/save_select_button_left.tscn
+++ b/scenes/lobby/save_select_button_left.tscn
@@ -1,0 +1,155 @@
+[gd_scene load_steps=9 format=3 uid="uid://bxuaysj7k43qf"]
+
+[ext_resource type="Texture2D" uid="uid://bvduv0j3kdwtj" path="res://assets/css/question.png" id="1_f2xas"]
+[ext_resource type="Script" uid="uid://sfd02iv24sre" path="res://scripts/ui/lobby/save_select_button.gd" id="1_sayp3"]
+[ext_resource type="Theme" uid="uid://d2oqlxohwao3c" path="res://assets/styles/battle_settings_menu.tres" id="2_dei1p"]
+[ext_resource type="AudioStream" uid="uid://cb75c45y5yhvk" path="res://sound/fx/click.wav" id="4_h4wc0"]
+
+[sub_resource type="Animation" id="Animation_8827p"]
+resource_name = "hover"
+length = 0.4
+loop_mode = 2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(400, 80), Vector2(420, 80)]
+}
+
+[sub_resource type="Animation" id="Animation_sayp3"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(400, 80)]
+}
+
+[sub_resource type="Animation" id="Animation_h4wc0"]
+resource_name = "select"
+length = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.25),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(400, 80), Vector2(470, 80), Vector2(460, 80)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_h4wc0"]
+_data = {
+&"RESET": SubResource("Animation_sayp3"),
+&"hover": SubResource("Animation_8827p"),
+&"select": SubResource("Animation_h4wc0")
+}
+
+[node name="SaveSelectButtonLeft" type="Button"]
+texture_filter = 1
+custom_minimum_size = Vector2(400, 80)
+offset_right = 400.0
+offset_bottom = 80.0
+toggle_mode = true
+script = ExtResource("1_sayp3")
+
+[node name="InnerControl" type="Control" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_bottom = -8.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 1
+
+[node name="CharacterDisplay" type="Panel" parent="InnerControl"]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_top = -32.0
+offset_right = 64.0
+offset_bottom = 32.0
+grow_vertical = 2
+mouse_filter = 1
+
+[node name="CharacterRect" type="TextureRect" parent="InnerControl/CharacterDisplay"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -32.0
+offset_top = -32.0
+offset_right = 32.0
+offset_bottom = 32.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("1_f2xas")
+stretch_mode = 2
+
+[node name="LabelControl" type="Panel" parent="InnerControl"]
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 72.0
+mouse_filter = 1
+
+[node name="SaveName" type="Label" parent="InnerControl/LabelControl"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+offset_left = 8.0
+offset_right = 92.0
+offset_bottom = 30.0
+mouse_filter = 1
+theme = ExtResource("2_dei1p")
+text = "Save 1"
+
+[node name="PlayerName" type="Label" parent="InnerControl/LabelControl"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = -30.0
+offset_right = 92.0
+grow_vertical = 0
+mouse_filter = 1
+theme = ExtResource("2_dei1p")
+text = "Empty"
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_h4wc0")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+&"": SubResource("AnimationLibrary_h4wc0")
+}
+
+[connection signal="focus_entered" from="." to="." method="_on_hover_entered"]
+[connection signal="focus_exited" from="." to="." method="_on_hover_exit"]
+[connection signal="mouse_entered" from="." to="." method="_on_hover_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_hover_exit"]

--- a/scenes/lobby/save_select_button_left.tscn
+++ b/scenes/lobby/save_select_button_left.tscn
@@ -5,6 +5,21 @@
 [ext_resource type="Theme" uid="uid://d2oqlxohwao3c" path="res://assets/styles/battle_settings_menu.tres" id="2_dei1p"]
 [ext_resource type="AudioStream" uid="uid://cb75c45y5yhvk" path="res://sound/fx/click.wav" id="4_h4wc0"]
 
+[sub_resource type="Animation" id="Animation_sayp3"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(400, 80)]
+}
+
 [sub_resource type="Animation" id="Animation_8827p"]
 resource_name = "hover"
 length = 0.4
@@ -20,21 +35,6 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Vector2(400, 80), Vector2(420, 80)]
-}
-
-[sub_resource type="Animation" id="Animation_sayp3"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:custom_minimum_size")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(400, 80)]
 }
 
 [sub_resource type="Animation" id="Animation_h4wc0"]
@@ -70,6 +70,7 @@ script = ExtResource("1_sayp3")
 
 [node name="InnerControl" type="Control" parent="."]
 layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 8.0
@@ -107,15 +108,14 @@ grow_vertical = 2
 texture = ExtResource("1_f2xas")
 stretch_mode = 2
 
-[node name="LabelControl" type="Panel" parent="InnerControl"]
+[node name="SaveNamePanel" type="Panel" parent="InnerControl"]
 layout_mode = 1
-anchors_preset = -1
-anchor_right = 1.0
-anchor_bottom = 1.0
 offset_left = 72.0
+offset_right = 172.0
+offset_bottom = 30.0
 mouse_filter = 1
 
-[node name="SaveName" type="Label" parent="InnerControl/LabelControl"]
+[node name="SaveName" type="Label" parent="InnerControl/SaveNamePanel"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(64, 0)
 layout_mode = 1
@@ -126,20 +126,72 @@ mouse_filter = 1
 theme = ExtResource("2_dei1p")
 text = "Save 1"
 
-[node name="PlayerName" type="Label" parent="InnerControl/LabelControl"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(64, 0)
+[node name="PlayerNamePanel" type="Panel" parent="InnerControl"]
 layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_left = 8.0
+offset_left = 72.0
 offset_top = -30.0
-offset_right = 92.0
+offset_right = 242.0
 grow_vertical = 0
+mouse_filter = 1
+
+[node name="PlayerName" type="Label" parent="InnerControl/PlayerNamePanel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_right = -8.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 1
 theme = ExtResource("2_dei1p")
 text = "Empty"
+
+[node name="ScorePanel" type="Panel" parent="InnerControl"]
+layout_mode = 1
+offset_left = 180.0
+offset_right = 292.0
+offset_bottom = 30.0
+mouse_filter = 1
+
+[node name="ScoreLabel" type="Label" parent="InnerControl/ScorePanel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+offset_left = 8.0
+offset_right = 104.0
+offset_bottom = 30.0
+mouse_filter = 1
+theme = ExtResource("2_dei1p")
+text = "000000"
+
+[node name="CompletionPanel" type="Panel" parent="InnerControl"]
+layout_mode = 1
+offset_left = 300.0
+offset_right = 384.0
+offset_bottom = 30.0
+mouse_filter = 1
+
+[node name="CompletionLabel" type="Label" parent="InnerControl/CompletionPanel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_top = -15.0
+offset_right = 85.0
+offset_bottom = 15.0
+grow_vertical = 2
+mouse_filter = 1
+theme = ExtResource("2_dei1p")
+text = "0%"
+horizontal_alignment = 1
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_h4wc0")

--- a/scenes/lobby/save_select_button_right.tscn
+++ b/scenes/lobby/save_select_button_right.tscn
@@ -5,6 +5,21 @@
 [ext_resource type="Theme" uid="uid://d2oqlxohwao3c" path="res://assets/styles/battle_settings_menu.tres" id="2_py3m0"]
 [ext_resource type="AudioStream" uid="uid://cb75c45y5yhvk" path="res://sound/fx/click.wav" id="4_62xta"]
 
+[sub_resource type="Animation" id="Animation_sayp3"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(400, 80)]
+}
+
 [sub_resource type="Animation" id="Animation_8827p"]
 resource_name = "hover"
 length = 0.4
@@ -20,21 +35,6 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Vector2(400, 80), Vector2(420, 80)]
-}
-
-[sub_resource type="Animation" id="Animation_sayp3"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:custom_minimum_size")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(400, 80)]
 }
 
 [sub_resource type="Animation" id="Animation_h4wc0"]
@@ -70,6 +70,7 @@ script = ExtResource("1_py3m0")
 
 [node name="InnerControl" type="Control" parent="."]
 layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_top = 8.0
@@ -110,50 +111,105 @@ grow_vertical = 2
 texture = ExtResource("1_p66qi")
 stretch_mode = 2
 
-[node name="LabelControl" type="Panel" parent="InnerControl"]
-layout_mode = 1
-anchors_preset = -1
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_right = -72.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 1
-
-[node name="SaveName" type="Label" parent="InnerControl/LabelControl"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(64, 0)
+[node name="SaveNamePanel" type="Panel" parent="InnerControl"]
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -92.0
-offset_right = -8.0
+offset_left = -172.0
+offset_right = -72.0
 offset_bottom = 30.0
 grow_horizontal = 0
+mouse_filter = 1
+
+[node name="SaveName" type="Label" parent="InnerControl/SaveNamePanel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+offset_left = 8.0
+offset_right = 92.0
+offset_bottom = 30.0
 mouse_filter = 1
 theme = ExtResource("2_py3m0")
 text = "Save 1"
 horizontal_alignment = 2
 
-[node name="PlayerName" type="Label" parent="InnerControl/LabelControl"]
+[node name="PlayerNamePanel" type="Panel" parent="InnerControl"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -242.0
+offset_top = 34.0
+offset_right = -72.0
+offset_bottom = 64.0
+grow_horizontal = 0
+mouse_filter = 1
+
+[node name="PlayerName" type="Label" parent="InnerControl/PlayerNamePanel"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(64, 0)
 layout_mode = 1
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
+anchors_preset = -1
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -92.0
-offset_top = -30.0
+offset_left = 8.0
 offset_right = -8.0
-grow_horizontal = 0
-grow_vertical = 0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 1
 theme = ExtResource("2_py3m0")
 text = "Empty"
 horizontal_alignment = 2
+
+[node name="ScorePanel" type="Panel" parent="InnerControl"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -292.0
+offset_right = -180.0
+offset_bottom = 30.0
+grow_horizontal = 0
+mouse_filter = 1
+
+[node name="ScoreLabel" type="Label" parent="InnerControl/ScorePanel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+offset_left = 8.0
+offset_right = 104.0
+offset_bottom = 30.0
+mouse_filter = 1
+theme = ExtResource("2_py3m0")
+text = "000000"
+
+[node name="CompletionPanel" type="Panel" parent="InnerControl"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -384.0
+offset_right = -300.0
+offset_bottom = 30.0
+grow_horizontal = 0
+mouse_filter = 1
+
+[node name="CompletionLabel" type="Label" parent="InnerControl/CompletionPanel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_top = -15.0
+offset_right = 85.0
+offset_bottom = 15.0
+grow_vertical = 2
+mouse_filter = 1
+theme = ExtResource("2_py3m0")
+text = "0	%"
+horizontal_alignment = 1
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_62xta")

--- a/scenes/lobby/save_select_button_right.tscn
+++ b/scenes/lobby/save_select_button_right.tscn
@@ -1,0 +1,169 @@
+[gd_scene load_steps=9 format=3 uid="uid://ckjwenucikdus"]
+
+[ext_resource type="Texture2D" uid="uid://bvduv0j3kdwtj" path="res://assets/css/question.png" id="1_p66qi"]
+[ext_resource type="Script" uid="uid://sfd02iv24sre" path="res://scripts/ui/lobby/save_select_button.gd" id="1_py3m0"]
+[ext_resource type="Theme" uid="uid://d2oqlxohwao3c" path="res://assets/styles/battle_settings_menu.tres" id="2_py3m0"]
+[ext_resource type="AudioStream" uid="uid://cb75c45y5yhvk" path="res://sound/fx/click.wav" id="4_62xta"]
+
+[sub_resource type="Animation" id="Animation_8827p"]
+resource_name = "hover"
+length = 0.4
+loop_mode = 2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(400, 80), Vector2(420, 80)]
+}
+
+[sub_resource type="Animation" id="Animation_sayp3"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(400, 80)]
+}
+
+[sub_resource type="Animation" id="Animation_h4wc0"]
+resource_name = "select"
+length = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.25),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(400, 80), Vector2(470, 80), Vector2(460, 80)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_h4wc0"]
+_data = {
+&"RESET": SubResource("Animation_sayp3"),
+&"hover": SubResource("Animation_8827p"),
+&"select": SubResource("Animation_h4wc0")
+}
+
+[node name="SaveSelectButtonRight" type="Button"]
+texture_filter = 1
+custom_minimum_size = Vector2(400, 80)
+offset_right = 400.0
+offset_bottom = 80.0
+toggle_mode = true
+script = ExtResource("1_py3m0")
+
+[node name="InnerControl" type="Control" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -8.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 1
+
+[node name="CharacterDisplay" type="Panel" parent="InnerControl"]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -64.0
+offset_top = -32.0
+offset_bottom = 32.0
+grow_horizontal = 0
+grow_vertical = 2
+mouse_filter = 1
+
+[node name="CharacterRect" type="TextureRect" parent="InnerControl/CharacterDisplay"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -32.0
+offset_top = -32.0
+offset_right = 32.0
+offset_bottom = 32.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("1_p66qi")
+stretch_mode = 2
+
+[node name="LabelControl" type="Panel" parent="InnerControl"]
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -72.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 1
+
+[node name="SaveName" type="Label" parent="InnerControl/LabelControl"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -92.0
+offset_right = -8.0
+offset_bottom = 30.0
+grow_horizontal = 0
+mouse_filter = 1
+theme = ExtResource("2_py3m0")
+text = "Save 1"
+horizontal_alignment = 2
+
+[node name="PlayerName" type="Label" parent="InnerControl/LabelControl"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 0)
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -92.0
+offset_top = -30.0
+offset_right = -8.0
+grow_horizontal = 0
+grow_vertical = 0
+mouse_filter = 1
+theme = ExtResource("2_py3m0")
+text = "Empty"
+horizontal_alignment = 2
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_62xta")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+&"": SubResource("AnimationLibrary_h4wc0")
+}
+
+[connection signal="focus_entered" from="." to="." method="_on_hover_entered"]
+[connection signal="focus_exited" from="." to="." method="_on_hover_exit"]
+[connection signal="mouse_entered" from="." to="." method="_on_hover_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_hover_exit"]

--- a/scenes/lobby/sp_lobby.tscn
+++ b/scenes/lobby/sp_lobby.tscn
@@ -1,0 +1,61 @@
+[gd_scene load_steps=8 format=3 uid="uid://cui0yxsmxis71"]
+
+[ext_resource type="Script" uid="uid://d2cpplwd6ifoe" path="res://scripts/ui/lobby/sp_lobby.gd" id="1_418fn"]
+[ext_resource type="Texture2D" uid="uid://bsu1o1vymo51p" path="res://assets/aesprite/Domber doki cenario1.png" id="2_yd478"]
+[ext_resource type="Shader" uid="uid://c0qwo7bogo6j7" path="res://assets/shaders/blur.gdshader" id="3_t42mu"]
+[ext_resource type="PackedScene" uid="uid://cwhum362lt6ww" path="res://scenes/cssmenu/sp_character_select_screen.tscn" id="4_418fn"]
+[ext_resource type="PackedScene" uid="uid://mjnlboref67" path="res://scenes/lobby/save_select.tscn" id="4_j0dtp"]
+[ext_resource type="AudioStream" uid="uid://bsv6xvb7bqh1h" path="res://sound/mus/config_dragoon_cafe.ogg" id="8_jgiyh"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_m8hcm"]
+resource_local_to_scene = true
+shader = ExtResource("3_t42mu")
+shader_parameter/strength = 2.5
+
+[node name="Lobby" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 2
+size_flags_vertical = 2
+script = ExtResource("1_418fn")
+
+[node name="BG" type="Sprite2D" parent="."]
+self_modulate = Color(0.501961, 0.501961, 0.501961, 1)
+texture_filter = 1
+position = Vector2(576, 337.5)
+scale = Vector2(3, 3)
+texture = ExtResource("2_yd478")
+
+[node name="BGBlur" type="Panel" parent="."]
+material = SubResource("ShaderMaterial_m8hcm")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="SaveMenu" parent="." instance=ExtResource("4_j0dtp")]
+layout_mode = 1
+
+[node name="CharacterSelectScreen" parent="." instance=ExtResource("4_418fn")]
+visible = false
+
+[node name="ErrorDialog" type="AcceptDialog" parent="."]
+auto_translate_mode = 1
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("8_jgiyh")
+autoplay = true
+bus = &"Music"
+parameters/looping = true
+
+[connection signal="save_menu_back" from="SaveMenu" to="." method="get_back_to_menu"]
+[connection signal="save_menu_existing_save" from="SaveMenu" to="." method="_on_game_start"]
+[connection signal="save_menu_new_save" from="SaveMenu" to="." method="show_character_select_screen"]
+[connection signal="characters_back_pressed" from="CharacterSelectScreen" to="." method="show_save_menu_screen"]
+[connection signal="characters_confirmed" from="CharacterSelectScreen" to="." method="_on_game_start"]

--- a/scenes/lobby/sp_lobby.tscn
+++ b/scenes/lobby/sp_lobby.tscn
@@ -13,6 +13,7 @@ shader = ExtResource("3_t42mu")
 shader_parameter/strength = 2.5
 
 [node name="Lobby" type="Control"]
+process_mode = 3
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://dgfv37m0j3grk"]
+[gd_scene load_steps=12 format=3 uid="uid://dgfv37m0j3grk"]
 
 [ext_resource type="Script" uid="uid://bq6xc0g4f6lhf" path="res://scripts/ui/main_menu.gd" id="1_qmksv"]
 [ext_resource type="Texture2D" uid="uid://bsu1o1vymo51p" path="res://assets/aesprite/Domber doki cenario1.png" id="2_u3scb"]
@@ -9,7 +9,6 @@
 [ext_resource type="StyleBox" uid="uid://dah145apm30c3" path="res://assets/styles/main_menu_select_style.tres" id="7_2iy8e"]
 [ext_resource type="StyleBox" uid="uid://c07q8xvjxkea6" path="res://assets/styles/main_menu_style.tres" id="7_nrhvf"]
 [ext_resource type="PackedScene" uid="uid://drj31ll2cuftl" path="res://scenes/options_menu/options_menu.tscn" id="8_m4i44"]
-[ext_resource type="PackedScene" uid="uid://c7x6djajavw8b" path="res://scenes/debug_campaign_selector.tscn" id="9_jk1qb"]
 [ext_resource type="AudioStream" uid="uid://dblrdj6byp4o6" path="res://sound/mus/menu_doki_doki_comes_home.ogg" id="10_5dd4i"]
 [ext_resource type="PackedScene" uid="uid://c6osao13wt47c" path="res://scenes/doki_subscribe_link.tscn" id="11_flqon"]
 
@@ -104,13 +103,6 @@ metadata/_custom_type_script = "uid://boq3i75yls51h"
 [node name="OptionsMenu" parent="." instance=ExtResource("8_m4i44")]
 visible = false
 layout_mode = 1
-
-[node name="DebugCampaignSelector" parent="." instance=ExtResource("9_jk1qb")]
-layout_mode = 1
-offset_left = 8.0
-offset_top = 300.0
-offset_right = -773.0
-offset_bottom = -317.0
 
 [node name="DokiSubscribeLink" parent="." instance=ExtResource("11_flqon")]
 layout_mode = 1

--- a/scenes/pickups/virus.tscn
+++ b/scenes/pickups/virus.tscn
@@ -28,7 +28,7 @@ animations = [{
 atlas = ExtResource("2_sont1")
 region = Rect2(96, 0, 24, 24)
 
-[node name="Virus" type="Area2D"]
+[node name="Virus" type="Area2D" groups=["pickup_debuff_immunity"]]
 collision_layer = 16
 collision_mask = 2
 script = ExtResource("1_fqgox")

--- a/scripts/bomb/stationary_bomb.gd
+++ b/scripts/bomb/stationary_bomb.gd
@@ -192,7 +192,8 @@ func _on_detect_area_body_entered(body: Node2D):
 	if (body is Player || body is Enemy) && armed && mine:
 		show()
 		$AnimationPlayer.play("mine_explode")
-		world_data.set_tile(world_data.tiles.BOMB, self.global_position, bomb_root.boost + 2, false)
+		if world_data.is_tile(world_data.MINE, self.global_position):
+			world_data.set_tile(world_data.tiles.BOMB, self.global_position, bomb_root.boost + 2, false)
 	if body is Breakable:
 		body.crush.rpc()
 	if !(body in get_collision_exceptions()):

--- a/scripts/debug_campaign_selector.gd
+++ b/scripts/debug_campaign_selector.gd
@@ -40,18 +40,15 @@ func _ready() -> void:
 				user_file.close()
 
 			res_file.close()
-
 	_update_and_set(DEFAULT_GRAPH_NAME)
 
 func _update_and_set(item_name: String = DEFAULT_GRAPH_NAME):
 	_get_file_name_from_dir(LevelGraph.SAVE_PATH)
+	gamestate.current_graph = item_name
 	for idx in range(selector.item_count):
 		if selector.get_item_text(idx) == item_name:
 			selector.select(idx)
 			return
-
-func get_graph() -> String:
-	return selector.get_item_text(selector.selected)
 
 func _get_file_name_from_dir(path: String):
 	selector.clear()
@@ -73,9 +70,12 @@ func _on_graph_button_pressed():
 	else:
 		if has_node("LevelGraph"): return
 		add_child(level_graph_editor)
-	level_graph_editor.get_menu_hbox().get_node("LoadSaveLEdit").text = get_graph()
-	level_graph_editor.file_name = get_graph()
+	level_graph_editor.get_menu_hbox().get_node("LoadSaveLEdit").text = gamestate.current_graph
+	level_graph_editor.file_name = gamestate.current_graph
 	level_graph_editor.has_saved.connect(_update_and_set)
 
-	var graph_json_data: Dictionary = LevelGraph.load_json_file(get_graph())
+	var graph_json_data: Dictionary = LevelGraph.load_json_file(gamestate.current_graph)
 	level_graph_editor.load_graph(graph_json_data)
+
+func _on_campaign_selector_item_selected(idx: int):
+	gamestate.current_graph = selector.get_item_text(idx)

--- a/scripts/debug_campaign_selector.gd
+++ b/scripts/debug_campaign_selector.gd
@@ -41,6 +41,8 @@ func _ready() -> void:
 
 			res_file.close()
 	_update_and_set(DEFAULT_GRAPH_NAME)
+	if OS.is_debug_build(): self.show()
+	else: self.hide()
 
 func _update_and_set(item_name: String = DEFAULT_GRAPH_NAME):
 	_get_file_name_from_dir(LevelGraph.SAVE_PATH)
@@ -79,3 +81,7 @@ func _on_graph_button_pressed():
 
 func _on_campaign_selector_item_selected(idx: int):
 	gamestate.current_graph = selector.get_item_text(idx)
+
+func _input(event):
+	if event.is_action_pressed("toggle_debug"):
+		self.visible = !self.visible

--- a/scripts/enemy/boss.gd
+++ b/scripts/enemy/boss.gd
@@ -12,6 +12,7 @@ const MOTION_SPEED_DECREASE: int = TILE_SIZE / 2
 @onready var bomb_carry_sprite: Sprite2D = $BombSprite
 
 @export_subgroup("Boss variables")
+@export var is_secret_boss: bool = false
 @export var pickups: HeldPickups
 @export var ability_detector: Area2D
 @export var init_bomb_count: int = 1
@@ -126,6 +127,8 @@ func exploded(by_whom: int):
 	if(self.health >= 1): return
 	if !is_multiplayer_authority(): return
 	var pickup_type: int = globals.get_pickup_type_from_name(self.dropped_pickup)
+	if self.is_secret_boss:
+		pass #TODO: unlock mint for this player
 
 	if pickup_type == globals.pickups.NONE: return
 	var pickup: Pickup = globals.game.pickup_pool.request(pickup_type)

--- a/scripts/level_graph/level_graph.gd
+++ b/scripts/level_graph/level_graph.gd
@@ -149,7 +149,6 @@ func load_graph(graph_data: Dictionary):
 func _on_load_pressed():
 	if is_saved:
 		_on_load_confirmed()
-		self.grab_focus()
 		return
 
 	for sig_arr in confirmation_dialog.get_ok_button().pressed.get_connections():
@@ -162,11 +161,11 @@ func _on_load_pressed():
 	confirmation_dialog.get_ok_button().pressed.connect(_on_load_confirmed, CONNECT_ONE_SHOT)
 	confirmation_dialog.get_cancel_button().pressed.connect(confirmation_dialog.hide, CONNECT_ONE_SHOT)
 	confirmation_dialog.popup_centered()
-	self.grab_focus()
 
 func _on_load_confirmed():
 	confirmation_dialog.hide()
 	load_graph(load_json_file(file_name))
+	self.grab_focus()
 
 func _on_save_pressed():
 	if !FileAccess.file_exists(SAVE_PATH + "/" + file_name + ".json"): 
@@ -184,7 +183,6 @@ func _on_save_pressed():
 	confirmation_dialog.get_ok_button().pressed.connect(_on_save_confirmed, CONNECT_ONE_SHOT)
 	confirmation_dialog.get_cancel_button().pressed.connect(confirmation_dialog.hide, CONNECT_ONE_SHOT)
 	confirmation_dialog.popup_centered()
-	self.grab_focus()
 
 ## saves the current graph
 func _on_save_confirmed():

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -97,7 +97,6 @@ func _ready():
 
 	movement_speed_reset = movement_speed
 	bomb_count_reset = bomb_count
-	print(bomb_count_reset)
 	explosion_boost_count_reset = explosion_boost_count
 	if globals.current_gamemode == globals.gamemode.CAMPAIGN:
 		player_health_updated.connect(func (s: Player, health: int): game_ui.update_health(health, int(s.name)))
@@ -115,7 +114,7 @@ func init_pickups():
 	if !is_multiplayer_authority(): return
 	for _speed_up in range(self.pickups.held_pickups[globals.pickups.SPEED_UP]):
 		increase_speed.rpc()
-	for _speed_down in range(self.pickups.held_pickups[globals.pickups.SPEED_UP]):
+	for _speed_down in range(self.pickups.held_pickups[globals.pickups.SPEED_DOWN]):
 		decrease_speed.rpc()
 	for _bomb_level_up in range(self.pickups.held_pickups[globals.pickups.FIRE_UP]):
 		increase_bomb_level.rpc()
@@ -573,6 +572,7 @@ func unvirus():
 	is_reverse = false
 	is_nonstop = false
 	is_unbomb = false
+	pickups.held_pickups[globals.pickups.VIRUS] = HeldPickups.virus.DEFAULT
 	set_process(false)
 
 func stop_time(user: String, is_player: bool):

--- a/scripts/player/player_spawner.gd
+++ b/scripts/player/player_spawner.gd
@@ -17,14 +17,6 @@ func _spawn_player(data) -> Player:
 		spawningplayer = ai_player_scene.instantiate()
 	spawningplayer.synced_position = data.spawndata
 	spawningplayer.name = str(data.pid)
-	#print("Data: ",data)
-	#print("Multiplayer Unique ID: ", multiplayer.get_unique_id())
-	#if data.pid == multiplayer.get_unique_id():
-		#print("Chosen Name: ", data.defaultname)
-	#elif (data.pid == 1):
-		#print("Derived Name: ", data.defaultname)
-	#else:
-		#print("Derived Name: ", data.playerdictionary[data.pid])
 	spawningplayer.set_player_name(data.defaultname if data.pid == multiplayer.get_unique_id() || data.pid == 1 else data.playerdict.playername)
 	spawningplayer.set_selected_character(data.playerdict.spritepaths.walk)
 	return spawningplayer

--- a/scripts/ui/cssmenu/sp_character_select_screen.gd
+++ b/scripts/ui/cssmenu/sp_character_select_screen.gd
@@ -1,0 +1,121 @@
+extends Control
+
+@onready var css_audio: AudioStreamPlayer = $AudioStreamPlayer
+@onready var character_texture_paths: CharacterSelectDataResource = preload("res://resources/css/character_texture_paths_default.tres")
+@onready var secret_1: TextureButton = $SkinBG/CharacterGrid/secret1
+@onready var secret_2: TextureButton = $SkinBG/CharacterGrid/secret2
+@onready var last_selected_panel: Panel = %CharacterGrid.get_node("eggoon/Panel")
+
+@export var supersecretvisible := false
+
+signal characters_confirmed
+signal characters_back_pressed
+
+var error_sound: AudioStreamWAV = load("res://sound/fx/error.wav")
+var select_sound: AudioStreamWAV = load("res://sound/fx/click.wav")
+
+func _ready() -> void:
+	if supersecretvisible:
+		secret_1.show()
+		secret_2.show()
+
+
+func enter() -> void:
+	show()
+
+	# select the default
+	show_selected_panel("eggoon")
+	gamestate.current_save.character_paths = character_texture_paths.egggoon_paths
+	gamestate.current_save.player_name = "Player1"
+	%PlayerName.text = ""
+
+
+func play_error_audio() -> void:
+	css_audio.stream = error_sound
+	css_audio.play()
+
+@rpc("any_peer", "call_local")
+func play_select_audio() -> void:
+	css_audio.stream = select_sound
+	css_audio.play()
+
+func show_selected_panel(character: String):
+	if last_selected_panel: last_selected_panel.hide()
+	last_selected_panel = %CharacterGrid.get_node(character + "/Panel")
+	last_selected_panel.show()
+
+func _on_eggoon_pressed() -> void:
+	show_selected_panel("eggoon")
+	gamestate.current_save.character_paths = character_texture_paths.egggoon_paths
+	play_select_audio.rpc()
+	
+func _on_dragoon_pressed() -> void:
+	show_selected_panel("dragoon")
+	gamestate.current_save.character_paths = character_texture_paths.normalgoon_paths
+	play_select_audio.rpc()
+	
+func _on_chonkgoon_pressed() -> void:
+	show_selected_panel("chonkgoon")
+	gamestate.current_save.character_paths = character_texture_paths.chonkgoon_paths
+	play_select_audio.rpc()
+	
+func _on_longoon_pressed() -> void:
+	show_selected_panel("longoon")
+	gamestate.current_save.character_paths = character_texture_paths.longgoon_paths
+	play_select_audio.rpc()
+	
+func _on_dad_pressed() -> void:
+	show_selected_panel("dad")
+	gamestate.current_save.character_paths = character_texture_paths.dad_paths
+	play_select_audio.rpc()
+
+func _on_bhdoki_pressed() -> void:
+	show_selected_panel("bhdoki")
+	gamestate.current_save.character_paths = character_texture_paths.bhdoki_paths
+	play_select_audio.rpc()
+
+func _on_retrodoki_pressed() -> void:
+	show_selected_panel("retrodoki")
+	gamestate.current_save.character_paths = character_texture_paths.retrodoki_paths
+	play_select_audio.rpc()
+
+func _on_altdoki_pressed() -> void:
+	show_selected_panel("altdoki")
+	gamestate.current_save.character_paths = character_texture_paths.altgirldoki_paths
+	play_select_audio.rpc()
+
+func _on_crowki_pressed() -> void:
+	show_selected_panel("crowki")
+	gamestate.current_save.character_paths = character_texture_paths.crowki_paths
+	play_select_audio.rpc()
+
+func _on_tomato_pressed() -> void:
+	show_selected_panel("tomato")
+	gamestate.current_save.character_paths = character_texture_paths.tomatodoki_paths
+	play_select_audio.rpc()
+
+func _on_secret_1_pressed() -> void:
+	if not supersecretvisible:
+		play_error_audio() #Not yet available
+	else:
+		show_selected_panel("secret1")
+		gamestate.current_save.character_paths = character_texture_paths.secretone_paths
+		play_select_audio.rpc()
+
+func _on_secret_2_pressed() -> void:
+	if not supersecretvisible:
+		play_error_audio() #Not yet available
+	else:
+		show_selected_panel("secret2")
+		gamestate.current_save.character_paths = character_texture_paths.secrettwo_paths
+		play_select_audio.rpc()
+
+func _on_exit_pressed() -> void:
+	characters_back_pressed.emit()
+
+func _on_confirm_pressed() -> void:
+	characters_confirmed.emit()
+
+func _on_player_name_text_changed(new_text: String) -> void:
+	if new_text == "": gamestate.current_save.player_name = "Player1"
+	else: gamestate.current_save.player_name = new_text

--- a/scripts/ui/cssmenu/sp_character_select_screen.gd.uid
+++ b/scripts/ui/cssmenu/sp_character_select_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://diwfw63wskeam

--- a/scripts/ui/ingame_ui/singleplayer_win_status.gd
+++ b/scripts/ui/ingame_ui/singleplayer_win_status.gd
@@ -24,6 +24,7 @@ func init_screen(score: int):
 	show()
 
 func _on_exit_game_pressed():
+	get_tree().paused = false
 	gamestate.end_sp_game()
 
 

--- a/scripts/ui/lobby/save_menu.gd
+++ b/scripts/ui/lobby/save_menu.gd
@@ -1,0 +1,86 @@
+extends Control
+
+signal save_menu_new_save
+signal save_menu_existing_save
+signal save_menu_back
+
+
+@onready var save_buttons_file: Dictionary = {
+	%SaveSelectButton_1: "save_1",
+	%SaveSelectButton_2: "save_2",
+	%SaveSelectButton_3: "save_3",
+	%SaveSelectButton_4: "save_4",
+	%SaveSelectButton_5: "save_5",
+	%SaveSelectButton_6: "save_6",
+	}
+
+@onready var save_buttons: Dictionary = {
+	%SaveSelectButton_1: {},
+	%SaveSelectButton_2: {},
+	%SaveSelectButton_3: {},
+	%SaveSelectButton_4: {},
+	%SaveSelectButton_5: {},
+	%SaveSelectButton_6: {},
+	}
+
+@onready var next: Button = %Next
+@onready var delete: Button = %Delete
+@onready var back: Button = %Back
+@onready var confirmation_dialog: ConfirmationDialog = $ConfirmationDialog
+
+var save_button_group: ButtonGroup
+
+func _ready() -> void:
+	delete.disabled = true
+	next.disabled = true
+	save_button_group = ButtonGroup.new()
+	for button in save_buttons.keys():
+		# setup each save button
+		button.button_group = save_button_group
+		save_button_group.pressed.connect(button._on_toggled)
+		button.set_save_name(int(button.name.right(1)))
+
+		# read the save if it exists
+		if !campaign_save_manager.save_exist(save_buttons_file[button]): continue
+		save_buttons[button] = campaign_save_manager.load(save_buttons_file[button])
+
+		# populate savefile_button
+		button.set_player_name(save_buttons[button].player_name)
+		button.set_character(save_buttons[button].character_paths)
+		#TODO: write high score and completion percent to load button
+
+	save_button_group.pressed.connect(_on_button_group_pressed)
+
+
+func _on_button_group_pressed(button: BaseButton):
+	assert(save_buttons.has(button))
+	if !save_buttons[button].is_empty(): delete.disabled = false
+	else: delete.disabled = true
+	next.disabled = false
+
+func _on_next_pressed() -> void:
+	gamestate.current_save_file = save_buttons_file[save_button_group.get_pressed_button()]
+
+	if save_buttons[save_button_group.get_pressed_button()].is_empty():
+		gamestate.current_save = campaign_save_manager.get_new_save()
+		save_menu_new_save.emit()
+		return
+
+	gamestate.current_save = save_buttons[save_button_group.get_pressed_button()]
+	save_menu_existing_save.emit()
+
+func _on_delete_pressed() -> void:
+	confirmation_dialog.popup_centered()
+
+func _on_delete_confirmed():
+	var button: BaseButton = save_button_group.get_pressed_button()
+	campaign_save_manager.delete_save(save_buttons_file[button])
+	button.reset_to_empty()
+	save_buttons[button] = {}
+	confirmation_dialog.hide()
+
+func _on_delete_cancelled():
+	confirmation_dialog.hide()
+
+func _on_back_pressed() -> void:
+	save_menu_back.emit()

--- a/scripts/ui/lobby/save_menu.gd
+++ b/scripts/ui/lobby/save_menu.gd
@@ -42,12 +42,19 @@ func _ready() -> void:
 
 		# read the save if it exists
 		if !campaign_save_manager.save_exist(save_buttons_file[button]): continue
-		save_buttons[button] = campaign_save_manager.load(save_buttons_file[button])
+		var save: Dictionary = campaign_save_manager.load(save_buttons_file[button])
+		if save.campaign_version != LevelGraph.VERSION: continue # if the version of the stage updated refuse to load it since it could cause game breaking bugs
+		save_buttons[button] = save
 
 		# populate savefile_button
 		button.set_player_name(save_buttons[button].player_name)
 		button.set_character(save_buttons[button].character_paths)
-		#TODO: write high score and completion percent to load button
+		button.set_score_label(save_buttons[button].current_score)
+		var total_stages_visited: int = 0
+		for stage in save_buttons[button].visited_exits.keys():
+			total_stages_visited += len(save_buttons[button].visited_exits[stage].keys())
+		button.set_completion_label(float(total_stages_visited) / save_buttons[button].exit_count)
+
 
 	save_button_group.pressed.connect(_on_button_group_pressed)
 

--- a/scripts/ui/lobby/save_menu.gd.uid
+++ b/scripts/ui/lobby/save_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://b4vallsu2hqgv

--- a/scripts/ui/lobby/save_select_button.gd
+++ b/scripts/ui/lobby/save_select_button.gd
@@ -1,0 +1,42 @@
+extends Button
+
+@onready var character_rect: TextureRect = %CharacterRect
+@onready var save_name_label: Label = %SaveName
+@onready var player_name_label: Label = %PlayerName
+@onready var anim: AnimationPlayer = $AnimationPlayer
+@onready var audio_player: AudioStreamPlayer = $AudioStreamPlayer
+@onready var empty_save_texture = character_rect.texture.duplicate()
+
+var is_toggled_on: bool = false
+
+func _on_hover_entered():
+	if self.is_toggled_on: return
+	anim.play("hover")
+
+func _on_hover_exit():
+	if self.is_toggled_on: return
+	anim.play("RESET")
+
+func _on_toggled(button: BaseButton) -> void:
+	self.is_toggled_on = button == self
+	if self.is_toggled_on:
+		anim.play("select")
+		audio_player.play()
+	else: anim.play("RESET")
+
+func set_save_name(nr: int):
+	save_name_label.text = "SAVE " + str(nr)
+
+func set_player_name(player_name: String):
+	player_name_label.text = player_name
+
+func set_character(character_paths: Dictionary):
+	assert(character_paths.has("select"))
+	character_rect.texture = load(character_paths.select)
+
+func reset_to_empty():
+	player_name_label.text = "Empty"
+	character_rect.texture = empty_save_texture.duplicate()
+
+# TODO: have highscore and completion rate displayed
+	

--- a/scripts/ui/lobby/save_select_button.gd
+++ b/scripts/ui/lobby/save_select_button.gd
@@ -3,6 +3,8 @@ extends Button
 @onready var character_rect: TextureRect = %CharacterRect
 @onready var save_name_label: Label = %SaveName
 @onready var player_name_label: Label = %PlayerName
+@onready var score_label: Label = %ScoreLabel
+@onready var completion_label: Label = %CompletionLabel
 @onready var anim: AnimationPlayer = $AnimationPlayer
 @onready var audio_player: AudioStreamPlayer = $AudioStreamPlayer
 @onready var empty_save_texture = character_rect.texture.duplicate()
@@ -30,13 +32,21 @@ func set_save_name(nr: int):
 func set_player_name(player_name: String):
 	player_name_label.text = player_name
 
+func set_score_label(score: int):
+	var format_string = "%06d"
+	score_label.set_text(format_string % [score])
+
+func set_completion_label(val: float):
+	completion_label.text = str(int(val * 100)) + "%"
+
 func set_character(character_paths: Dictionary):
 	assert(character_paths.has("select"))
 	character_rect.texture = load(character_paths.select)
 
 func reset_to_empty():
 	player_name_label.text = "Empty"
+	var format_string = "%06d"
+	score_label.set_text(format_string % [0])
+	completion_label.text = "0%"
 	character_rect.texture = empty_save_texture.duplicate()
 
-# TODO: have highscore and completion rate displayed
-	

--- a/scripts/ui/lobby/save_select_button.gd.uid
+++ b/scripts/ui/lobby/save_select_button.gd.uid
@@ -1,0 +1,1 @@
+uid://sfd02iv24sre

--- a/scripts/ui/lobby/sp_lobby.gd
+++ b/scripts/ui/lobby/sp_lobby.gd
@@ -1,0 +1,42 @@
+extends Control
+
+@onready var save_select_screen: Control = $SaveMenu
+@onready var character_select_screen: Control = $CharacterSelectScreen
+
+func _ready() -> void:
+	gamestate.game_ended.connect(_on_game_ended)
+	gamestate.game_error.connect(_on_game_error)
+	show_save_menu_screen()
+	
+func show_save_menu_screen() -> void:
+	save_select_screen.show()
+	character_select_screen.hide()
+
+func show_character_select_screen() -> void:
+	assert(gamestate.current_save_file != "")
+	assert(gamestate.current_save.has("character_paths"))
+	assert(gamestate.current_save.has("player_name"))
+	character_select_screen.enter()
+	save_select_screen.hide()
+	
+func hide_all_lobby_screens() -> void:
+	hide()
+	character_select_screen.hide()
+
+func get_back_to_menu() -> void:
+	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+
+func _on_game_error(errtxt):
+	if is_inside_tree():
+		$ErrorDialog.dialog_text = errtxt
+		$ErrorDialog.popup_centered()
+	
+func _on_game_start() -> void:
+	gamestate.begin_singleplayer_game()
+	hide_all_lobby_screens()
+
+func _on_error_dialog_confirmed() -> void:
+	get_back_to_menu()
+
+func _on_game_ended():
+	get_back_to_menu()

--- a/scripts/ui/lobby/sp_lobby.gd.uid
+++ b/scripts/ui/lobby/sp_lobby.gd.uid
@@ -1,0 +1,1 @@
+uid://d2cpplwd6ifoe

--- a/scripts/ui/main_menu.gd
+++ b/scripts/ui/main_menu.gd
@@ -35,7 +35,7 @@ func unpause_main_menu_music() -> void:
 	main_menu_music_player.stream_paused = false
 	
 func _on_single_player_pressed() -> void:
-	gamestate.begin_singleplayer_game()
+	get_tree().change_scene_to_file("res://scenes/lobby/sp_lobby.tscn")
 	hide();
 
 func _on_multiplayer_pressed() -> void:

--- a/scripts/ui/main_menu.gd
+++ b/scripts/ui/main_menu.gd
@@ -2,7 +2,6 @@ extends Control
 @onready var title_sceen: Node2D = $TitleSceen
 @onready var button_box: VBoxContainer = $ButtonBox
 @onready var options_menu: Control = $OptionsMenu
-@onready var graph_selection: Control = $DebugCampaignSelector
 @onready var main_menu_music_player: AudioStreamPlayer = $AudioStreamPlayer
 
 # Called when the node enters the scene tree for the first time.
@@ -17,13 +16,11 @@ func switch_to_options_menu() -> void:
 	options_menu.options_music_player.play()
 	
 func hide_main_menu() -> void:
-	graph_selection.hide()
 	title_sceen.hide()
 	button_box.hide()
 	$DokiSubscribeLink.hide()
 	
 func reveal_main_menu() -> void:
-	graph_selection.show()
 	title_sceen.visible = true
 	button_box.visible = true
 	$DokiSubscribeLink.show()

--- a/scripts/world/world.gd
+++ b/scripts/world/world.gd
@@ -19,6 +19,8 @@ class_name World
 
 signal all_enemied_died
 
+const EXIT_VISITED_COLOR: Color = Color8(187, 32, 144)
+
 @export_group("World Settings")
 ## The Rectangle that covers the playable area where (x,y) are the top left corner and (w, h) the size of the rectangle all in tile coordinates
 @export var _arena_rect: Rect2i
@@ -64,8 +66,13 @@ func spawn_exits():
 			"exit at position " + str(exit_entry.coords) + " is out of bounds for current stage")
 		assert(!world_data.is_tile(world_data.tiles.UNBREAKABLE, exit_pos),
 			"exit at position " + str(exit_entry.coords) + " is ontop of an unbreakable")
-		var exit = globals.game.exit_pool.request(exit_entry.color)
-		exit.place(exit_pos, children_ids[iter])
+
+		var exit: Exit
+		if gamestate.current_save.visited_exits.has(globals.game.curr_stage_idx) && gamestate.current_save.visited_exits[globals.game.curr_stage_idx].has(children_ids[iter]):
+			exit = globals.game.exit_pool.request(EXIT_VISITED_COLOR)
+		else:
+			exit = globals.game.exit_pool.request(exit_entry.color)
+		exit.place(exit_pos, children_ids[iter]) 
 		iter += 1
 
 ## Disabled this world so another may be enabled


### PR DESCRIPTION
- [x] Saves Selection Menu UI
- [x] Character and Name Selection UI
- [x] Store and display character and name on the save selection
- [x] Squash the thing between main menu and start game 
- [x] Load data on campaign start
- [x] actively update the save data during gameplay
- [x] write save-data pack to json
- [x] color overwrite visited exit portals with a unique color do indicate it having already been visited. 
- [x] move the debug graph selector to the char / name select ui 
- [x] hide the debug graph selector in builds where the `export with debug` option is turned off but can be toggled with `F3` 
- [x] clear saves if new graph version is detected.
- [x] write completion percentage and score on the button

Polish ideas (parity / future PR):
While I think the save buttons look okey we can make a modified version of the planks from the UI onor made and the face icons and make a more themed version of the save button. While keeping the bounce / apply animation