### PR TITLE
changed bomb throwing mechanics

### DIFF
--- a/scripts/bomb/bomb_root_fsm.gd
+++ b/scripts/bomb/bomb_root_fsm.gd
@@ -176,20 +176,16 @@ func do_throw(direction: Vector2i, new_position: Vector2):
 		-PI / 6,
 		0.4
 	)
-	world_data.set_tile(world_data.tiles.EMPTY, self.global_position)
 	return 0
 
 @rpc("call_local")
 func carry():
-	if state != STATIONARY:
+	if state != DISABLED:
 		return
 	if self.type == HeldPickups.bomb_types.MINE:
 		return
-
-	fuse_time_passed = state_map[state].get_node("AnimationPlayer").current_animation_position
 	self.in_use = false
 	set_state(AIRBORN)
-	world_data.set_tile(world_data.tiles.EMPTY, self.global_position)
 
 @rpc("call_local")
 func do_kick(direction: Vector2i):

--- a/scripts/player/human_player_controls.gd
+++ b/scripts/player/human_player_controls.gd
@@ -6,6 +6,7 @@ var motion = Vector2():
 		motion = clamp(value, Vector2(-1, -1), Vector2(1, 1))
 
 var bombing := false
+var hold_bomb := false
 var throw_ability := false
 var punch_ability := false
 var secondary_ability := false
@@ -29,6 +30,5 @@ func update():
 		m *= Vector2(-1, -1)
 	motion = m
 	bombing = Input.is_action_pressed("set_bomb")
-	throw_ability = Input.is_action_just_released("set_bomb")
 	punch_ability = Input.is_action_pressed("punch_action")
 	secondary_ability = Input.is_action_just_pressed("secondary_action")


### PR DESCRIPTION
fixes picking up a bomb right after placing it
timer for checking how long a player holds bomb button
- default is > 0.5 to carry, any less and its placed

bomb now goes straight to carry -> throw instead of place -> carry -> throw