### PR TITLE
Explosion detection rewrite

### DIFF
--- a/scenes/bombs/stationary_bomb.tscn
+++ b/scenes/bombs/stationary_bomb.tscn
@@ -29,7 +29,7 @@ resource_name = "explosion_small"
 
 [sub_resource type="Animation" id="Animation_21j5c"]
 resource_name = "fuse_and_call_detonate()"
-length = 4.0
+length = 3.0
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true

--- a/scenes/explosion.tscn
+++ b/scenes/explosion.tscn
@@ -61,7 +61,7 @@ tile_set = ExtResource("2_544pj")
 
 [node name="Area2D" type="Area2D" parent="."]
 collision_layer = 64
-collision_mask = 58
+collision_mask = 62
 
 [node name="x-line" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("SegmentShape2D_5as2d")

--- a/scripts/bomb/explosion.gd
+++ b/scripts/bomb/explosion.gd
@@ -3,8 +3,8 @@ class_name Explosion extends Node2D
 signal is_finished_exploding
 signal has_killed
 
-@onready var tilemap = get_node("SpriteTileMap")
-@onready var detection_area = get_node("Area2D")
+@onready var tilemap: TileMapLayer = $SpriteTileMap
+@onready var detection_area: Area2D = $Area2D
 
 var right
 var down
@@ -71,7 +71,7 @@ func init_detonate(right_score: int, down_score: int = right, left_score: int = 
 	self.down = down_score
 	self.left = left_score
 	self.up = up_score
-
+	print("r:",right,"\td:",down,"\tl:",left,"\tu:",up)
 	next_detonate()
 	var tile_size: float = tilemap.tile_set.tile_size.x
 	if left > 0:
@@ -79,7 +79,7 @@ func init_detonate(right_score: int, down_score: int = right, left_score: int = 
 	if right > 0:
 		detection_area.get_child(0).shape.b = Vector2(right * tile_size, 0)
 	if up > 0:
-		detection_area.get_child(1).shape.a = Vector2(0, - up * tile_size)
+		detection_area.get_child(1).shape.a = Vector2(0, -up * tile_size)
 	if down > 0:
 		detection_area.get_child(1).shape.b = Vector2(0, down * tile_size)
 

--- a/scripts/bomb/explosion.gd
+++ b/scripts/bomb/explosion.gd
@@ -71,7 +71,7 @@ func init_detonate(right_score: int, down_score: int = right, left_score: int = 
 	self.down = down_score
 	self.left = left_score
 	self.up = up_score
-	print("r:",right,"\td:",down,"\tl:",left,"\tu:",up)
+
 	next_detonate()
 	var tile_size: float = tilemap.tile_set.tile_size.x
 	if left > 0:

--- a/scripts/bomb/stationary_bomb.gd
+++ b/scripts/bomb/stationary_bomb.gd
@@ -118,11 +118,12 @@ func detonate():
 			var origin := map.local_to_map(self.global_position)
 			var collision := map.local_to_map(ray.get_collision_point())
 			var range := absi((origin - collision).length())
-			if target.is_class("TileMapLayer"):
-				range -= 1
 			if ray_direction == Vector2i.LEFT or ray_direction == Vector2i.UP:
 				range += 1
-			if world_data.is_out_of_bounds(ray.get_collision_point()) != world_data.bounds.IN:
+			if target.is_class("TileMapLayer"):
+				range -= 1
+			var bounds_check := self.global_position + Vector2(ray_direction * range * TILE_SIZE)
+			if world_data.is_out_of_bounds(bounds_check) != world_data.bounds.IN:
 				range -= 1
 			exp_range[ray_direction] = clampi(range, 0, MAX_EXPLOSION_WIDTH)
 	if bomb_root.bomb_owner:


### PR DESCRIPTION
fixes #414 
also fixes undiscovered piercing bug
Bomb now relies on the explosion animation to kill, rather than using itself and the animation.
Explosion also covers the object instead of stopping right before.