### PR TITLE
Issue #360 fix (Misobon sprite should now accurately represent the player sprite)

### DIFF
--- a/scripts/player/misobon/misobon_player.gd
+++ b/scripts/player/misobon/misobon_player.gd
@@ -33,6 +33,7 @@ func _process(_delta: float) -> void:
 ## set the given player to the owner of this misobon player
 func set_player(player_id: int):
 	self.player = get_node("../../Players/" + str(player_id))
+	$sprite.texture = player.get_node("./sprite").texture
 
 @rpc("call_local")
 func enable(starting_progress: float):


### PR DESCRIPTION
Swapped default sprite texture of misobon as the assigned player's sprite texture when player is set.