### PR TITLE
Fixed Timeout Draws and Hurry Up Speed

### DIFF
--- a/scenes/battlemode_game.tscn
+++ b/scenes/battlemode_game.tscn
@@ -398,7 +398,7 @@ pivot_offset = Vector2(52.5, 74.5)
 size_flags_horizontal = 4
 theme = ExtResource("15_egtpy")
 theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 0.355007)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 0)
 theme_override_constants/outline_size = 25
 theme_override_font_sizes/font_size = 161
 text = "1"
@@ -409,4 +409,5 @@ metadata/_edit_use_anchors_ = true
 [node name="ErrorDialog" type="AcceptDialog" parent="."]
 auto_translate_mode = 1
 
+[connection signal="matchtimer_timeout" from="MultiplayerGameUI" to="." method="_on_multiplayer_game_ui_matchtimer_timeout"]
 [connection signal="confirmed" from="ErrorDialog" to="." method="_on_error_dialog_confirmed"]

--- a/scenes/ingame_ui/battlemode_game_ui.tscn
+++ b/scenes/ingame_ui/battlemode_game_ui.tscn
@@ -63,3 +63,5 @@ layout_mode = 2
 [node name="ScorePanel_P4" parent="ScorePanelContainer" instance=ExtResource("4_xmooi")]
 visible = false
 layout_mode = 2
+
+[connection signal="timeout" from="MatchTimer" to="." method="_on_match_timer_timeout"]

--- a/scenes/lobby/component/hurry_up_time_slider.tscn
+++ b/scenes/lobby/component/hurry_up_time_slider.tscn
@@ -38,7 +38,9 @@ theme_override_styles/separator = SubResource("StyleBoxEmpty_4k2yx")
 custom_minimum_size = Vector2(200, 32)
 layout_mode = 2
 size_flags_vertical = 1
+min_value = 30.0
 max_value = 600.0
+value = 30.0
 rounded = true
 
 [node name="VSeparator2" type="VSeparator" parent="HBoxContainer"]

--- a/scripts/battlemode_game.gd
+++ b/scripts/battlemode_game.gd
@@ -70,6 +70,8 @@ func lock_misobon():
 func start_stage_start_countdown() -> Signal:
 	game_anim_player.play("countdown")
 	return game_anim_player.animation_finished
+	#Animation contains unfreeze_players()
+	#Animation contains activate_ui_and_music()
 
 func activate_ui_and_music():
 	stage.start_music()
@@ -104,11 +106,11 @@ func stop_the_match():
 	game_ended = true
 	stage.stop_music()
 	stage.stop_hurry_up()
-	%MatchTimer.stop()
-	game_ui.stop_timer()
+	if not %MatchTimer.is_stopped():
+		%MatchTimer.stop()
+		game_ui.stop_timer()
 	lock_misobon()
 	defuse_all_bombs()
-	# Halt Hurry Up
 	
 func play_fade_out():
 	game_anim_player.play("fade_out")
@@ -165,3 +167,16 @@ func _on_error_dialog_confirmed() -> void:
 		gamestate.peer.close()
 	if is_inside_tree():
 		get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+
+
+func _on_multiplayer_game_ui_matchtimer_timeout() -> void:
+	#DRAW GAME DUE TO TIME
+	stop_the_match()
+	freeze_players()
+	await play_fade_out()
+	await get_tree().create_timer(2).timeout
+	#RESET GAME STATE
+	reset_players() 
+	wipe_stage() #Must occur after players reset to avoid AI pathing error.
+	#LOAD NEW STAGE
+	load_new_stage()

--- a/scripts/ui/ingame_ui/battlemode_game_ui.gd
+++ b/scripts/ui/ingame_ui/battlemode_game_ui.gd
@@ -4,6 +4,8 @@ extends CanvasLayer
 @onready var score_panel_container: Container = %ScorePanelContainer
 @onready var time_label: Label = %TimeLabel
 
+signal matchtimer_timeout
+
 const COLOR_ARR: Array[Color] = [Color8(255, 100, 100), Color8(100, 255, 255), Color8(255, 178, 100), Color8(163, 255, 156)]
 
 var player_labels = {}
@@ -73,3 +75,7 @@ func _on_hurry_up_start() -> void:
 
 func reset() -> void:
 	time_label.add_theme_color_override("font_color", Color(255, 255, 255))
+
+
+func _on_match_timer_timeout() -> void:
+	matchtimer_timeout.emit()

--- a/scripts/ui/lobby/hurry_up_time_setting.gd
+++ b/scripts/ui/lobby/hurry_up_time_setting.gd
@@ -11,8 +11,15 @@ func set_slider_value(newval : int) -> void:
 	h_slider.value = newval
 	
 func set_chance_num_label_text() -> void:
-	slider_number_label.text = str(int(h_slider.value)) + " seconds"
+	slider_number_label.text = time_to_string(h_slider.value)
 
+func time_to_string(time := 120.0) -> String:
+	var seconds = fmod(time, 60)
+	var minutes = time / 60
+	var format_string = "%02d:%02d"
+	var actual_time_string = format_string % [minutes, seconds]
+	return actual_time_string
+	
 func _on_value_changed(value: float) -> void:
 	set_chance_num_label_text()
 	SettingsSignalBus.emit_on_hurry_up_time_set(value)

--- a/scripts/ui/lobby/match_time_setting.gd
+++ b/scripts/ui/lobby/match_time_setting.gd
@@ -11,8 +11,16 @@ func set_slider_value(newval : int) -> void:
 	h_slider.value = newval
 	
 func set_chance_num_label_text() -> void:
-	slider_number_label.text = str(int(h_slider.value)) + " seconds"
+	slider_number_label.text = time_to_string(h_slider.value)
 
+
+func time_to_string(time := 120.0) -> String:
+	var seconds = fmod(time, 60)
+	var minutes = time / 60
+	var format_string = "%02d:%02d"
+	var actual_time_string = format_string % [minutes, seconds]
+	return actual_time_string
+	
 func _on_value_changed(value: float) -> void:
 	set_chance_num_label_text()
 	SettingsSignalBus.emit_on_match_time_set(value)

--- a/scripts/world/hurry_up.gd
+++ b/scripts/world/hurry_up.gd
@@ -33,11 +33,12 @@ func start() -> void:
 	var hurry_up_time: float = SettingsContainer.get_hurry_up_time() + 1.5 #idk wy this +1.5 is needed but otherwise it does not stop at a nice 00:00
 	var total_number_of_non_unbreakable_spaces: int
 	if !SettingsContainer.get_sudden_death_state():
-		total_number_of_non_unbreakable_spaces = get_sudden_death_non_unbreakable_spaces()
+		total_number_of_non_unbreakable_spaces = get_final_area_non_unbreakable_spaces()
 	else:
 		total_number_of_non_unbreakable_spaces = globals.current_world.total_number_of_non_unbreakable_spaces
 
-	var falling_unbreakable_speed: float = hurry_up_time / total_number_of_non_unbreakable_spaces
+	#Sudden death and Normal Hurry Up should fall at the same speed.
+	var falling_unbreakable_speed: float = hurry_up_time / globals.current_world.total_number_of_non_unbreakable_spaces
 	hurry_up_step_timer.wait_time = falling_unbreakable_speed
 	assert(falling_unbreakable_speed != 0)
 	var anim_time: float = 0.5
@@ -52,7 +53,7 @@ func connect_hurry_up_signals():
 	if not hurry_up_start.is_connected(globals.game.game_ui._on_hurry_up_start):
 		hurry_up_start.connect(globals.game.game_ui._on_hurry_up_start)
 
-func get_sudden_death_non_unbreakable_spaces():
+func get_final_area_non_unbreakable_spaces():
 	var count: int = 0
 	@warning_ignore("INTEGER_DIVISION") # this is supposed to be an int div still don't now wy this is even a warning
 	var top_left: Vector2i = Vector2i((world_data.world_width - FINAL_ARENA_SIZE.x) / 2, (world_data.world_height - FINAL_ARENA_SIZE.y) / 2)


### PR DESCRIPTION
- Draws now cause all players to freeze in place and then restart similar to if everyone died.
- Hurry Up Speed is now always the same for Sudden Death or not, making sure that if there is a 9x7 safe area at the end, it fills in with time to spare.